### PR TITLE
Define pixels per routes

### DIFF
--- a/packages/meta-pixel/package.json
+++ b/packages/meta-pixel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-pixel",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "author": "tanukijs <tanuki.contact@gmail.com>",
   "description": "Wrapper for meta pixels",

--- a/packages/meta-pixel/src/meta-pixel.ts
+++ b/packages/meta-pixel/src/meta-pixel.ts
@@ -43,9 +43,14 @@ export function setup($fbq: FacebookQuery = addScriptDefault()): Setup {
     return setup($fbq)
   } 
   
-  function pageView () {
-    $fbq('track', 'PageView')
-    return { $fbq }
+  function pageView (pixelId?: string) {
+    if (pixelId === undefined) {
+      $fbq('track', 'PageView')
+    } else {
+      $fbq('trackSingle', pixelId, 'PageView')
+    }
+
+    return setup($fbq)
   }
 
   return {

--- a/packages/meta-pixel/src/meta-pixel.ts
+++ b/packages/meta-pixel/src/meta-pixel.ts
@@ -1,5 +1,7 @@
 import type { FacebookQuery, Setup } from './typings'
 
+export * from './typings'
+
 export function addScript(f: Window, b: Document, e: string, v: string, n?: any, t?: HTMLScriptElement, s?: HTMLScriptElement): FacebookQuery {
   if (f.fbq) { return f.fbq }
 
@@ -11,7 +13,7 @@ export function addScript(f: Window, b: Document, e: string, v: string, n?: any,
       // eslint-disable-next-line prefer-rest-params
       n.queue.push(arguments)
     }
-  }
+  } as unknown as FacebookQuery
 
   if (!f._fbq) { f._fbq = n }
 

--- a/packages/meta-pixel/src/typings.ts
+++ b/packages/meta-pixel/src/typings.ts
@@ -44,6 +44,7 @@ interface FacebookQueryExtra {
 
 // @see https://developers.facebook.com/docs/meta-pixel/reference/
 export interface FacebookQuery {
+  disablePushState: boolean
   (command: 'init', pixelId: string, data?: InitData): void
   (command: 'set', key: string, value1: any, value2: any): void
   (command: 'track', event: 'AddPaymentInfo', data?: AddPaymentInfoData, extra?: FacebookQueryExtra): void

--- a/packages/meta-pixel/src/typings.ts
+++ b/packages/meta-pixel/src/typings.ts
@@ -94,7 +94,7 @@ export interface FacebookQuery {
 export interface Setup {
   $fbq: FacebookQuery
   init(pixelId: string, autoconfig?: boolean): Setup
-  pageView(): Pick<Setup, '$fbq'>
+  pageView(pixelId?: string): Setup
 } 
 
 declare global {

--- a/packages/nuxt-meta-pixel/README.md
+++ b/packages/nuxt-meta-pixel/README.md
@@ -1,12 +1,3 @@
-<!--
-Get your module up and running quickly.
-
-Find and replace all on all files (CMD+SHIFT+F):
-- Name: My Module
-- Package name: my-module
-- Description: My new Nuxt module
--->
-
 # nuxt-meta-pixel
 
 [![Nuxt][nuxt-src]][nuxt-href]
@@ -19,10 +10,9 @@ Find and replace all on all files (CMD+SHIFT+F):
 ## Features
 
 <!-- Highlight some of the features your module provide here -->
-- ⛰ &nbsp;Load one or more meta pixels.
-- 🚠 &nbsp; configurable `noscript` & `autoconfig`.
-- 🚠 &nbsp;`PageView` event sent automatically.
-- 🌲 &nbsp;Allows you to use `track`, `trackSingle`, `trackCustom`, `trackSingleCustom` and every features of a pixel in your application.
+- 🤖 &nbsp;Load one or more meta pixels.
+- ⚙️ &nbsp;Automaticallly send `PageView` event based on route match.
+- 🚀 &nbsp;All tracking methods available: `track`, `trackSingle`, `trackCustom` & `trackSingleCustom`.
 
 ## Quick Setup
 
@@ -32,25 +22,31 @@ Install the module to your Nuxt application with one command:
 npx nuxi module add nuxt-meta-pixel
 ```
 
-That's it! You can now use My Module in your Nuxt app ✨
+That's it! You can now use `nuxt-meta-pixel` in your Nuxt app ✨
 
 ## Getting started
 
+### Pixel parameters
+- **id** `string` - your pixel id
+- **autoconfig** `boolean` (default: `true`) - enable or disable pixel autoconfig. [see more](https://developers.facebook.com/docs/meta-pixel/advanced/?locale=fr_FR)
+- **pageView** `string` (default: `**`) - glob expression to decide which route or not should send a PageView event automatically. [see more](https://www.npmjs.com/package/minimatch)
+
+### Module configuration
+The module can also be configured under the key `metaPixel`.
 ```ts
 // nuxt.config.ts
 // This example show how to load multiple pixels
 
 export default defineNuxtConfig({
   modules: [
-    'nuxt-meta-pixel'
+    ['nuxt-meta-pixel', {
+      pixels: [
+        { id: '101010100100101' },
+        { id: '445554445454554', autoconfig: false },
+        { id: '223323232323323', pageView: '/posts/**' },
+      ]
+    }]
   ],
-  metaPixel: {
-    pixels: [
-      { id: '101010100100101', noscript: true },
-      { id: '223323232323323' },
-      { id: '445554445454554', autoconfig: false },
-    ]
-  }
 })
 ```
 
@@ -60,8 +56,11 @@ export default defineNuxtConfig({
 
 <script setup lang="ts">
 const { $fbq } = useNuxtApp()
-$fbq('track', 'CompleteRegistration')
-$fbq('trackSingle', YOUR_PIXEL_ID, 'CompleteRegistration')
+
+onMounted(() => {
+  $fbq('track', 'CompleteRegistration')
+  $fbq('trackSingle', YOUR_PIXEL_ID, 'CompleteRegistration')
+})
 </script>
 
 <template>

--- a/packages/nuxt-meta-pixel/package.json
+++ b/packages/nuxt-meta-pixel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-meta-pixel",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "license": "MIT",
   "author": "tanukijs <tanuki.contact@gmail.com>",
   "description": "Nuxt wrapper for meta pixels",

--- a/packages/nuxt-meta-pixel/package.json
+++ b/packages/nuxt-meta-pixel/package.json
@@ -46,7 +46,8 @@
   "dependencies": {
     "@nuxt/kit": "^3.11.1",
     "defu": "^6.1.4",
-    "meta-pixel": "^1.0.0"
+    "meta-pixel": "^1.0.0",
+    "minimatch": "^9.0.4"
   },
   "devDependencies": {
     "@nuxt/devtools": "latest",

--- a/packages/nuxt-meta-pixel/playground/app.vue
+++ b/packages/nuxt-meta-pixel/playground/app.vue
@@ -2,9 +2,11 @@
 const { $fbq } = useNuxtApp()
 const YOUR_PIXEL_ID = ''
 
-$fbq('track', 'CompleteRegistration')
-$fbq('trackSingle', YOUR_PIXEL_ID, 'CompleteRegistration')
-$fbq('track', 'AddToCart')
+onMounted(() => {
+  // $fbq('track', 'CompleteRegistration')
+  // $fbq('trackSingle', YOUR_PIXEL_ID, 'CompleteRegistration')
+  // $fbq('track', 'AddToCart')
+})
 </script>
 
 <template>

--- a/packages/nuxt-meta-pixel/playground/nuxt.config.ts
+++ b/packages/nuxt-meta-pixel/playground/nuxt.config.ts
@@ -2,9 +2,9 @@ export default defineNuxtConfig({
   modules: ['../src/module'],
   metaPixel: {
     pixels: [
-      { id: '1176370652884847', noscript: true },
-      { id: '415215247513663' },
-      { id: '415215247513664' },
+      { id: '1176370652884847', noscript: true, pageView: '/posts/**' },
+      // { id: '415215247513663' },
+      // { id: '415215247513664', pageView: '/about/**' },
     ]
   },
   devtools: { enabled: true }

--- a/packages/nuxt-meta-pixel/playground/nuxt.config.ts
+++ b/packages/nuxt-meta-pixel/playground/nuxt.config.ts
@@ -2,7 +2,7 @@ export default defineNuxtConfig({
   modules: ['../src/module'],
   metaPixel: {
     pixels: [
-      { id: '1176370652884847', noscript: true, pageView: '/posts/**' },
+      { id: '1176370652884847', pageView: '/posts/**' },
       // { id: '415215247513663' },
       // { id: '415215247513664', pageView: '/about/**' },
     ]

--- a/packages/nuxt-meta-pixel/playground/pages/about.vue
+++ b/packages/nuxt-meta-pixel/playground/pages/about.vue
@@ -1,4 +1,8 @@
 <template>
-  <h1>about page</h1>
-  <NuxtLink :to="{name: 'index'}">Go to index</NuxtLink>
+  <div>
+    <h1>about page</h1>
+    <NuxtLink :to="{name: 'index'}">
+      Go to index
+    </NuxtLink>
+  </div>
 </template>

--- a/packages/nuxt-meta-pixel/playground/pages/index.vue
+++ b/packages/nuxt-meta-pixel/playground/pages/index.vue
@@ -1,4 +1,35 @@
 <template>
-  <h1>index page</h1>
-  <NuxtLink :to="{name: 'about'}">Go to about</NuxtLink>
+  <div>
+    <h1 id="first">
+      index page
+    </h1>
+    <ul>
+      <li>
+        <NuxtLink :to="{hash: '#second'}">
+          Go to second title
+        </NuxtLink>
+      </li>
+      <li>
+        <NuxtLink :to="{name: 'about'}">
+          Go to about
+        </NuxtLink>
+      </li>
+      <li>
+        <NuxtLink :to="{name: 'posts-slug', params: {slug: 'meta-pixel'}}">
+          Go to posts
+        </NuxtLink>
+      </li>
+    </ul>
+
+    <h2 id="second">
+      second title
+    </h2>
+    <ul>
+      <li>
+        <NuxtLink :to="{hash: '#first'}">
+          Go to first title
+        </NuxtLink>
+      </li>
+    </ul>
+  </div>
 </template>

--- a/packages/nuxt-meta-pixel/playground/pages/posts/[slug].vue
+++ b/packages/nuxt-meta-pixel/playground/pages/posts/[slug].vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+const route = useRoute()
+</script>
+
+<template>
+  <div>
+    <h1 id="first">
+      posts/{{ route.params.slug }}
+    </h1>
+    <ul>
+      <li>
+        <NuxtLink :to="{name: 'index'}">
+          Go to index
+        </NuxtLink>
+      </li>
+      <li>
+        <NuxtLink :to="{name: 'posts-slug', params: {slug: 'meta-pixel'}}">
+          Go to meta-pixel
+        </NuxtLink>
+      </li>
+      <li>
+        <NuxtLink :to="{name: 'posts-slug', params: {slug: 'nuxt-meta-pixel'}}">
+          Go to nuxt-meta-pixel
+        </NuxtLink>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/packages/nuxt-meta-pixel/src/module.ts
+++ b/packages/nuxt-meta-pixel/src/module.ts
@@ -18,14 +18,6 @@ export default defineNuxtModule<ModuleOptions>({
   },
   setup (options, nuxt) {
     const resolver = createResolver(import.meta.url)
-    const head = nuxt.options.app.head
-    head.noscript ??= []
-    
-    for (const pixel of options.pixels) {
-      if (pixel.noscript === true) {
-        head.noscript.push({ innerHTML: `<img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=${pixel.id}&ev=PageView&noscript=1"/>` })
-      }
-    }
     
     nuxt.options.runtimeConfig.public.metaPixel = defu(
       nuxt.options.runtimeConfig.public.metaPixel,

--- a/packages/nuxt-meta-pixel/src/module.ts
+++ b/packages/nuxt-meta-pixel/src/module.ts
@@ -1,15 +1,6 @@
-import { defineNuxtModule, addPlugin, createResolver } from '@nuxt/kit'
+import { addPlugin, createResolver, defineNuxtModule } from '@nuxt/kit'
 import { defu } from 'defu'
-
-export interface Pixel {
-  id: string
-  noscript?: boolean
-  autoconfig?: boolean
-}
-
-export interface ModuleOptions {
-  pixels: Pixel[]
-}
+import type { ModuleOptions } from './typings'
 
 declare module 'nuxt/schema' {
   interface PublicRuntimeConfig {

--- a/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
+++ b/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
@@ -1,17 +1,30 @@
 import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
+import { isNavigationFailure } from '#vue-router'
 import { setup, type FacebookQuery } from 'meta-pixel'
+import { minimatch } from 'minimatch'
 import type { Plugin } from 'nuxt/app'
 
 export default defineNuxtPlugin(() => {
   const runtimeConfig = useRuntimeConfig()
   const opts = runtimeConfig.public.metaPixel
   const { $fbq, init, pageView } = setup()
-  
+  $fbq.disablePushState = true
+
   for (const pixel of opts.pixels) {
     init(pixel.id, pixel.autoconfig)
   }
 
-  pageView()
+  const router = useRouter()
+  router.afterEach((to, _, failure) => {
+    if (isNavigationFailure(failure)) return
+
+    for (const pixel of opts.pixels) {
+      const match = minimatch(to.path, pixel.pageView ?? '**')
+      if (match) {
+        pageView(pixel.id)
+      }
+    }
+  })
 
   return {
     provide: {

--- a/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
+++ b/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
@@ -1,6 +1,5 @@
 import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
-import { setup } from 'meta-pixel'
-import type { FacebookQuery } from 'meta-pixel/lib/typings'
+import { setup, type FacebookQuery } from 'meta-pixel'
 import type { Plugin } from 'nuxt/app'
 
 export default defineNuxtPlugin(() => {

--- a/packages/nuxt-meta-pixel/src/typings.ts
+++ b/packages/nuxt-meta-pixel/src/typings.ts
@@ -1,6 +1,5 @@
 export interface Pixel {
   id: string
-  noscript?: boolean
   autoconfig?: boolean
   pageView?: string
 }

--- a/packages/nuxt-meta-pixel/src/typings.ts
+++ b/packages/nuxt-meta-pixel/src/typings.ts
@@ -2,6 +2,7 @@ export interface Pixel {
   id: string
   noscript?: boolean
   autoconfig?: boolean
+  pageView?: string
 }
 
 export interface ModuleOptions {

--- a/packages/nuxt-meta-pixel/src/typings.ts
+++ b/packages/nuxt-meta-pixel/src/typings.ts
@@ -1,0 +1,9 @@
+export interface Pixel {
+  id: string
+  noscript?: boolean
+  autoconfig?: boolean
+}
+
+export interface ModuleOptions {
+  pixels: Pixel[]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6240,7 +6240,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3":
+"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3, minimatch@npm:^9.0.4":
   version: 9.0.4
   resolution: "minimatch@npm:9.0.4"
   dependencies:
@@ -6849,6 +6849,7 @@ __metadata:
     defu: "npm:^6.1.4"
     eslint: "npm:^8.57.0"
     meta-pixel: "npm:^1.0.0"
+    minimatch: "npm:^9.0.4"
     nuxt: "npm:^3.11.1"
     typescript: "npm:^5.4.5"
     vitest: "npm:^1.4.0"


### PR DESCRIPTION
#6 

- Send PageView event based on a `pageView` configuration ([minimatch](https://www.npmjs.com/package/minimatch) pattern)
- Handle [navigation failures](https://v3.router.vuejs.org/guide/advanced/navigation-failures.html) (like duplication)


See [Facebook blog post](https://developers.facebook.com/ads/blog/post/2017/05/29/tagging-a-single-page-application-facebook-pixel/)
See [Facebook documentation](https://developers.facebook.com/docs/meta-pixel/implementation/tag_spa/)