### PR TITLE
feat: add option to enable or disable module

### DIFF
--- a/packages/nuxt-meta-pixel/README.md
+++ b/packages/nuxt-meta-pixel/README.md
@@ -40,9 +40,12 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       metapixel: {
-        default: { id: '1176370652884847', pageView: '/posts/**' },
-        ads01: { id: '415215247513663' },
-        ads02: { id: '415215247513664', pageView: '!/posts/**' },
+        enabled: process.env.NODE_ENV === 'production',
+        pixels: {
+          default: { id: '1176370652884847', pageView: '/posts/**' },
+          ads01: { id: '415215247513663' },
+          ads02: { id: '415215247513664', pageView: '!/posts/**' },
+        }
       }
     }
   }

--- a/packages/nuxt-meta-pixel/playground/nuxt.config.ts
+++ b/packages/nuxt-meta-pixel/playground/nuxt.config.ts
@@ -1,9 +1,16 @@
 export default defineNuxtConfig({
   modules: ['../src/module'],
-  metapixel: {
-    default: { id: '1176370652884847', pageView: '/posts/**' },
-    test01: { id: '415215247513663' },
-    test02: { id: '415215247513664', pageView: '!/posts/**' },
+  runtimeConfig: {
+    public: {
+     metapixel: {
+      enabled: true,
+      pixels: {
+        default: { id: '1176370652884847', pageView: '/posts/**' },
+        test01: { id: '415215247513663' },
+        test02: { id: '415215247513664', pageView: '!/posts/**' },
+      }
+     }
+    }
   },
   devtools: { enabled: true }
 })

--- a/packages/nuxt-meta-pixel/src/module.ts
+++ b/packages/nuxt-meta-pixel/src/module.ts
@@ -34,10 +34,6 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.vite.optimizeDeps.include ||= []
     nuxt.options.vite.optimizeDeps.include.push('brace-expansion')
 
-
-    addPlugin({
-      src: resolver.resolve('./runtime/plugin.client'),
-      mode: 'client'
-    })
+    addPlugin(resolver.resolve('./runtime/plugin.client'))
   }
 })

--- a/packages/nuxt-meta-pixel/src/module.ts
+++ b/packages/nuxt-meta-pixel/src/module.ts
@@ -13,6 +13,9 @@ export default defineNuxtModule<ModuleOptions>({
     name: 'nuxt-meta-pixel',
     configKey: 'metapixel'
   },
+  defaults: {
+    enabled: true,
+  },
   setup (options, nuxt) {
     const resolver = createResolver(import.meta.url)
     
@@ -20,6 +23,10 @@ export default defineNuxtModule<ModuleOptions>({
       nuxt.options.runtimeConfig.public.metapixel,
       options
     )
+    
+    if(!nuxt.options.runtimeConfig.public.metapixel.enabled) {
+      return
+    }
 
     // minimatch > brace-expansion
     // Ensure we transform these cjs dependencies, remove as they get converted to ejs
@@ -27,6 +34,10 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.vite.optimizeDeps.include ||= []
     nuxt.options.vite.optimizeDeps.include.push('brace-expansion')
 
-    addPlugin(resolver.resolve('./runtime/plugin.client'))
+
+    addPlugin({
+      src: resolver.resolve('./runtime/plugin.client'),
+      mode: 'client'
+    })
   }
 })

--- a/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
+++ b/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
@@ -6,7 +6,8 @@ import type { Plugin } from 'nuxt/app'
 
 export default defineNuxtPlugin(() => {
   const runtimeConfig = useRuntimeConfig()
-  const pixels = runtimeConfig.public.metapixel
+  const pixels = runtimeConfig.public.metapixel.pixels
+
   const { $fbq, init, pageView } = setup()
   $fbq.disablePushState = true
 

--- a/packages/nuxt-meta-pixel/src/typings.ts
+++ b/packages/nuxt-meta-pixel/src/typings.ts
@@ -5,5 +5,8 @@ export interface Pixel {
 }
 
 export interface ModuleOptions {
-  [name: string]: Pixel
+  enabled?: boolean
+  pixels: {
+    [name: string]: Pixel
+  }
 }


### PR DESCRIPTION
🔗 Linked issue

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

📚 Description
Added option to enable or disable the module. Can be very usefull if you don't want to disable the tag in development or staging. Had to move the pixels configuration to subkey inside the metapixel object which makes it a breaking change. 