### PR TITLE
Adding Gdpr consent

### DIFF
--- a/packages/meta-pixel/src/meta-pixel.ts
+++ b/packages/meta-pixel/src/meta-pixel.ts
@@ -37,7 +37,8 @@ export function addScriptDefault() {
 }
 
 export function setup($fbq: FacebookQuery = addScriptDefault()): Setup {
-  function init (pixelId: string, autoconfig: boolean = true) {
+  function init (pixelId: string, autoconfig: boolean = true, consent: string = 'grant') {
+    $fbq('consent', consent)
     $fbq('set', 'autoConfig', autoconfig, pixelId)
     $fbq('init', pixelId)
     return setup($fbq)

--- a/packages/meta-pixel/src/typings.ts
+++ b/packages/meta-pixel/src/typings.ts
@@ -78,7 +78,7 @@ export interface FacebookQuery {
 
 export interface Setup {
   $fbq: FacebookQuery
-  init(pixelId: string, autoconfig?: boolean): Setup
+  init(pixelId: string, autoconfig?: boolean, consent?: string): Setup
   pageView(pixelId?: string): Setup
 } 
 

--- a/packages/meta-pixel/src/typings.ts
+++ b/packages/meta-pixel/src/typings.ts
@@ -67,6 +67,7 @@ type Args<T, E extends keyof T> = T[E] extends (...args: infer A) => void ? A : 
 // @see https://developers.facebook.com/docs/meta-pixel/reference/
 export interface FacebookQuery {
   disablePushState: boolean;
+  (command: 'consent', consent: string): void
   (command: 'init', pixelId: string, data?: InitData): void
   (command: 'set', key: string, value1: any, value2: any): void
   <E extends keyof Events>(command: 'track', event: E, ...args: Args<Events, E>): void

--- a/packages/nuxt-meta-pixel/README.md
+++ b/packages/nuxt-meta-pixel/README.md
@@ -54,6 +54,7 @@ export default defineNuxtConfig({
 - **id** `string` - your pixel id
 - **autoconfig** `boolean` (default: `true`) - enable or disable pixel autoconfig. [see more](https://developers.facebook.com/docs/meta-pixel/advanced/?locale=fr_FR)
 - **pageView** `string` (default: `**`) - glob expression to decide which route or not should send a PageView event automatically. [see more](https://www.npmjs.com/package/minimatch)
+- **consent** `string` (default: `grant`) - set gdpr consent. Can be `grant` or `revoke`. [see more](https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/)
 
 ### Environment variables
 ```env

--- a/packages/nuxt-meta-pixel/README.md
+++ b/packages/nuxt-meta-pixel/README.md
@@ -34,13 +34,14 @@ The module can also be configured under the key `metapixel`.
 ```ts
 // nuxt.config.ts
 // This example show how to load multiple pixels
+// GDPR: Set consent to 'revoke' to be GDPR compliant and grant consent through $fbq after your cookiebanner has been accepted.
 
 export default defineNuxtConfig({
   modules: ['nuxt-meta-pixel'],
   runtimeConfig: {
     public: {
       metapixel: {
-        default: { id: '1176370652884847', pageView: '/posts/**' },
+        default: { id: '1176370652884847', pageView: '/posts/**', consent: 'revoke' },
         ads01: { id: '415215247513663' },
         ads02: { id: '415215247513664', pageView: '!/posts/**' },
       }
@@ -77,6 +78,14 @@ onMounted(() => {
   $fbq('track', 'CompleteRegistration')
   $fbq('trackSingle', YOUR_PIXEL_ID, 'CompleteRegistration')
 })
+
+const cookiebannerAccepted = () => {
+  $fbq('constent', 'grant');
+}
+
+const cookiebannerRevoked = () => {
+  $fbq('consent', 'revoke');
+}
 </script>
 
 <template>
@@ -88,6 +97,7 @@ onMounted(() => {
 - [Conversion Tracking](https://developers.facebook.com/docs/meta-pixel/implementation/conversion-tracking/?locale=fr_FR)
 - [Events](https://developers.facebook.com/docs/meta-pixel/reference/)
 - [Accurate Event Tracking with Multiple Pixels](https://developers.facebook.com/ads/blog/post/v2/2017/11/28/event-tracking-with-multiple-pixels-tracksingle/)
+- [GDPR consent](https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/)
 
 
 ## Contribution

--- a/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
+++ b/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
@@ -12,7 +12,7 @@ export default defineNuxtPlugin(() => {
 
   for (const name in pixels) {
     const pixel = pixels[name]
-    init(pixel.id.toString(), pixel.autoconfig)
+    init(pixel.id.toString(), pixel.autoconfig, pixel.consent)
   }
 
   const router = useRouter()

--- a/packages/nuxt-meta-pixel/src/typings.ts
+++ b/packages/nuxt-meta-pixel/src/typings.ts
@@ -1,5 +1,6 @@
 export interface Pixel {
   id: number | string
+  consent?: string
   autoconfig?: boolean
   pageView?: string
 }


### PR DESCRIPTION
This adds GDPR consent to the meta-pixel and nuxt-meta-pixel package, following https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/

This has been done by adding a consent parameter to the pixel config and init function.
By default the consent parameter is "grant", so pixels without this parameter will stay working.
To be GDPR compliant, the parameter needs to be set to 'revoke' in the pixel configuration, and later set to 'grant' with $fbq.consent('grant') after the user's cookie consent has been retrieved.

