### PR TITLE
fix: replace minimatch with a built-in glob matcher (#14, #20)

### DIFF
--- a/packages/nuxt-meta-pixel/package.json
+++ b/packages/nuxt-meta-pixel/package.json
@@ -46,8 +46,7 @@
   "dependencies": {
     "@nuxt/kit": "^3.11.1",
     "defu": "^6.1.4",
-    "meta-pixel": "^1.1.0",
-    "minimatch": "^9.0.4"
+    "meta-pixel": "^1.1.0"
   },
   "devDependencies": {
     "@nuxt/devtools": "latest",

--- a/packages/nuxt-meta-pixel/src/module.ts
+++ b/packages/nuxt-meta-pixel/src/module.ts
@@ -21,12 +21,6 @@ export default defineNuxtModule<ModuleOptions>({
       options
     )
 
-    // minimatch > brace-expansion
-    // Ensure we transform these cjs dependencies, remove as they get converted to ejs
-    nuxt.options.vite.optimizeDeps ||= {}
-    nuxt.options.vite.optimizeDeps.include ||= []
-    nuxt.options.vite.optimizeDeps.include.push('brace-expansion')
-
     addPlugin(resolver.resolve('./runtime/plugin.client'))
   }
 })

--- a/packages/nuxt-meta-pixel/src/runtime/glob.ts
+++ b/packages/nuxt-meta-pixel/src/runtime/glob.ts
@@ -1,0 +1,51 @@
+/**
+ * Minimal, dependency-free glob matcher for route paths.
+ *
+ * Replaces `minimatch` to avoid the `brace-expansion` ESM interop crash in Vite
+ * dev (see issues #14 and #20). Only the subset used for `pageView` patterns is
+ * supported:
+ *   - `**` matches any characters, including `/`
+ *   - `*`  matches any characters except `/` (a single path segment)
+ *   - `?`  matches a single character except `/`
+ *   - a leading `!` negates the whole pattern
+ */
+
+const SPECIAL = new Set('.+^${}()|[]\\'.split(''))
+
+function globToRegExp(glob: string): RegExp {
+  let re = ''
+
+  for (let i = 0; i < glob.length; i++) {
+    const char = glob[i]
+
+    if (char === '*') {
+      if (glob[i + 1] === '*') {
+        re += '.*'
+        i++
+      } else {
+        re += '[^/]*'
+      }
+    } else if (char === '?') {
+      re += '[^/]'
+    } else if (SPECIAL.has(char)) {
+      re += '\\' + char
+    } else {
+      re += char
+    }
+  }
+
+  return new RegExp('^' + re + '$')
+}
+
+export function matchPath(path: string, pattern: string): boolean {
+  let negate = false
+  let glob = pattern
+
+  while (glob[0] === '!') {
+    negate = !negate
+    glob = glob.slice(1)
+  }
+
+  const matched = globToRegExp(glob).test(path)
+  return negate ? !matched : matched
+}

--- a/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
+++ b/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
@@ -1,7 +1,7 @@
 import { defineNuxtPlugin, useRouter, useRuntimeConfig } from '#imports'
 import { isNavigationFailure } from '#vue-router'
 import { setup, type FacebookQuery } from 'meta-pixel'
-import { minimatch } from 'minimatch'
+import { matchPath } from './glob'
 import type { Plugin } from 'nuxt/app'
 
 export default defineNuxtPlugin(() => {
@@ -21,7 +21,7 @@ export default defineNuxtPlugin(() => {
 
     for (const name in pixels) {
       const pixel = pixels[name]
-      const match = minimatch(to.path, pixel.pageView ?? '**')
+      const match = matchPath(to.path, pixel.pageView ?? '**')
       if (match) {
         pageView(pixel.id.toString())
       }

--- a/packages/nuxt-meta-pixel/test/glob.test.ts
+++ b/packages/nuxt-meta-pixel/test/glob.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { matchPath } from '../src/runtime/glob'
+
+describe('matchPath', () => {
+  it('matches everything with the default `**`', () => {
+    expect(matchPath('/', '**')).toBe(true)
+    expect(matchPath('/posts/hello', '**')).toBe(true)
+  })
+
+  it('matches a section with a globstar', () => {
+    expect(matchPath('/posts/hello', '/posts/**')).toBe(true)
+    expect(matchPath('/posts/hello/world', '/posts/**')).toBe(true)
+    expect(matchPath('/about', '/posts/**')).toBe(false)
+  })
+
+  it('does not let a single star cross path separators', () => {
+    expect(matchPath('/posts', '/*')).toBe(true)
+    expect(matchPath('/posts/hello', '/*')).toBe(false)
+  })
+
+  it('supports negation with a leading `!`', () => {
+    expect(matchPath('/posts/hello', '!/posts/**')).toBe(false)
+    expect(matchPath('/about', '!/posts/**')).toBe(true)
+  })
+
+  it('matches a single character with `?`', () => {
+    expect(matchPath('/a', '/?')).toBe(true)
+    expect(matchPath('/ab', '/?')).toBe(false)
+  })
+
+  it('treats regex metacharacters as literals', () => {
+    expect(matchPath('/posts.html', '/posts.html')).toBe(true)
+    expect(matchPath('/postsXhtml', '/posts.html')).toBe(false)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -6153,7 +6153,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"meta-pixel@npm:^1.0.0, meta-pixel@workspace:packages/meta-pixel":
+"meta-pixel@npm:^1.1.0, meta-pixel@workspace:packages/meta-pixel":
   version: 0.0.0-use.local
   resolution: "meta-pixel@workspace:packages/meta-pixel"
   dependencies:
@@ -6240,7 +6240,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3, minimatch@npm:^9.0.4":
+"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3":
   version: 9.0.4
   resolution: "minimatch@npm:9.0.4"
   dependencies:
@@ -6848,8 +6848,7 @@ __metadata:
     changelogen: "npm:^0.5.5"
     defu: "npm:^6.1.4"
     eslint: "npm:^8.57.0"
-    meta-pixel: "npm:^1.0.0"
-    minimatch: "npm:^9.0.4"
+    meta-pixel: "npm:^1.1.0"
     nuxt: "npm:^3.11.1"
     typescript: "npm:^5.4.5"
     vitest: "npm:^1.4.0"


### PR DESCRIPTION
## Problem

`nuxt-meta-pixel` depends on `minimatch`, which pulls in `brace-expansion` (CommonJS). On recent Nuxt/Vite versions this crashes the dev server with:

> `Uncaught SyntaxError: ... 'brace-expansion/index.js' does not provide an export named 'default'`

Reported in **#14** and **#20** (still reproduced on Nuxt 3.16 and Nuxt 4.2.2). The module currently ships a fragile `vite.optimizeDeps.include.push('brace-expansion')` workaround that no longer holds.

## Fix

- Remove the `minimatch` dependency entirely.
- Match `pageView` route patterns with a small, dependency-free matcher (`src/runtime/glob.ts`) supporting the only subset ever used: `**`, `*`, `?` and a leading `!` negation.
- Drop the now-useless `brace-expansion` `optimizeDeps` hack from `module.ts`.
- Add unit tests for the matcher.

This eliminates the entire `brace-expansion` ESM-interop class of bugs at the root, rather than patching Vite's optimizer.

## Verification

- `yarn dev:prepare` (module build) ✅
- New `test/glob.test.ts` — 6/6 ✅ covering the README patterns (`/posts/**`, `!/posts/**`, single-segment `*`, `?`, literal metachars).

> Note: the pre-existing e2e test `test/basic.test.ts` fails on this branch with a `#vue-router` stub error (`ENOENT vue-router-stub`) — this also fails on `dev` without these changes (verified) and is tied to the outdated `@nuxt/test-utils`/Nuxt 3.11 toolchain (see #12). It will be addressed by the dependency-update PR.

Fixes #14
Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)