### PR TITLE
fix: resolve #imports in published runtime, drop #vue-router (#12)

### DIFF
--- a/packages/nuxt-meta-pixel/src/module.ts
+++ b/packages/nuxt-meta-pixel/src/module.ts
@@ -15,11 +15,17 @@ export default defineNuxtModule<ModuleOptions>({
   },
   setup (options, nuxt) {
     const resolver = createResolver(import.meta.url)
-    
+
     nuxt.options.runtimeConfig.public.metapixel = defu(
       nuxt.options.runtimeConfig.public.metapixel,
       options
     )
+
+    // Transpile the runtime through Nuxt's pipeline so the `#imports` virtual
+    // alias used by the plugin resolves in consuming apps. Without this, a
+    // consumer's Vite may pre-bundle the runtime from node_modules and fail to
+    // resolve the alias (#12).
+    nuxt.options.build.transpile.push(resolver.resolve('./runtime'))
 
     addPlugin(resolver.resolve('./runtime/plugin.client'))
   }

--- a/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
+++ b/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
@@ -1,5 +1,4 @@
 import { defineNuxtPlugin, useRouter, useRuntimeConfig } from '#imports'
-import { isNavigationFailure } from '#vue-router'
 import { setup, type FacebookQuery } from 'meta-pixel'
 import { matchPath } from './glob'
 import type { Plugin } from 'nuxt/app'
@@ -17,7 +16,7 @@ export default defineNuxtPlugin(() => {
 
   const router = useRouter()
   router.afterEach((to, _, failure) => {
-    if (isNavigationFailure(failure)) return
+    if (failure) return
 
     for (const name in pixels) {
       const pixel = pixels[name]


### PR DESCRIPTION
## Problem (#12)

Some consumers hit:

> `Failed to resolve import "#vue-router" from "node_modules/nuxt-meta-pixel/dist/runtime/plugin.client.mjs?v=…"`

The plugin runtime imports Nuxt **virtual aliases** (`#imports`, `#vue-router`). When the consuming app's Vite **pre-bundles** the runtime from `node_modules` (the `?v=` hash is Vite's dev optimizeDeps), those aliases — which only exist inside Nuxt's build pipeline — can't be resolved. Same family as the `brace-expansion` issue fixed in #23.

## Fix

- **`nuxt.options.build.transpile.push(runtimeDir)`** — tells Nuxt to transpile the runtime through its own pipeline (where `#imports` is defined) instead of letting the consumer's Vite pre-bundle it. This is the canonical Nuxt-module remedy for this class of error.
- **Drop the `#vue-router` import** — in a router `afterEach` hook, `failure` is already `NavigationFailure | undefined`, so `if (failure) return` is equivalent to `isNavigationFailure(failure)`. Removes one fragile virtual-alias dependency entirely.

## Verification

Beyond the in-repo checks (lint 0/0, test 7/7, module + playground build ✅), I reproduced the **exact #12 context** with an external app:

1. `yarn pack`ed the module, created a fresh standalone Nuxt 3.21 app, `npm install`ed the tarball (so the module loads from `node_modules/.../dist/runtime`, and `meta-pixel` resolves from npm).
2. Ran `nuxi dev` and requested the plugin module through Vite.

Result — Vite transforms `dist/runtime/plugin.client.js` (with the optimizeDeps `?v=` hash) and resolves the alias correctly instead of failing:

```js
import { defineNuxtPlugin, useRuntimeConfig } from "/_nuxt/node_modules/nuxt/dist/app/nuxt.js?v=…";
import { useRouter } from "/_nuxt/node_modules/nuxt/dist/app/composables/router.js?v=…";
```

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)