### PR TITLE
feat: add GDPR consent support (#18)

### DIFF
--- a/packages/meta-pixel/src/meta-pixel.ts
+++ b/packages/meta-pixel/src/meta-pixel.ts
@@ -1,4 +1,4 @@
-import type { FacebookQuery, Setup } from './typings'
+import type { Consent, FacebookQuery, Setup } from './typings'
 
 export * from './typings'
 
@@ -37,11 +37,20 @@ export function addScriptDefault() {
 }
 
 export function setup($fbq: FacebookQuery = addScriptDefault()): Setup {
+  // `consent` is a global Meta Pixel setting (the command takes no pixel id),
+  // so it applies to every pixel. Call `consent('revoke')` BEFORE `init` to hold
+  // event delivery, then `consent('grant')` once the user has opted in.
+  // @see https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/
+  function consent (consent: Consent) {
+    $fbq('consent', consent)
+    return setup($fbq)
+  }
+
   function init (pixelId: string, autoconfig: boolean = true) {
     $fbq('set', 'autoConfig', autoconfig, pixelId)
     $fbq('init', pixelId)
     return setup($fbq)
-  } 
+  }
   
   function pageView (pixelId?: string) {
     if (pixelId === undefined) {
@@ -55,6 +64,7 @@ export function setup($fbq: FacebookQuery = addScriptDefault()): Setup {
 
   return {
     $fbq,
+    consent,
     init,
     pageView
   }

--- a/packages/meta-pixel/src/typings.ts
+++ b/packages/meta-pixel/src/typings.ts
@@ -64,9 +64,13 @@ type Events = {
 
 type Args<T, E extends keyof T> = T[E] extends (...args: infer A) => void ? A : never;
 
+// @see https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/
+export type Consent = 'grant' | 'revoke'
+
 // @see https://developers.facebook.com/docs/meta-pixel/reference/
 export interface FacebookQuery {
   disablePushState: boolean;
+  (command: 'consent', consent: Consent): void
   (command: 'init', pixelId: string, data?: InitData): void
   (command: 'set', key: string, value1: any, value2: any): void
   <E extends keyof Events>(command: 'track', event: E, ...args: Args<Events, E>): void
@@ -77,9 +81,10 @@ export interface FacebookQuery {
 
 export interface Setup {
   $fbq: FacebookQuery
+  consent(consent: Consent): Setup
   init(pixelId: string, autoconfig?: boolean): Setup
   pageView(pixelId?: string): Setup
-} 
+}
 
 declare global {
   interface Window {

--- a/packages/nuxt-meta-pixel/README.md
+++ b/packages/nuxt-meta-pixel/README.md
@@ -53,6 +53,42 @@ export default defineNuxtConfig({
 - **id** `string` - your pixel id
 - **autoconfig** `boolean` (default: `true`) - enable or disable pixel autoconfig. [see more](https://developers.facebook.com/docs/meta-pixel/advanced/?locale=fr_FR)
 - **pageView** `string` (default: `**`) - glob expression to decide which route or not should send a PageView event automatically. [see more](https://www.npmjs.com/package/minimatch)
+- **consent** `'grant' | 'revoke'` - GDPR consent. Set `revoke` to hold event delivery until the user opts in (see [GDPR consent](#gdpr-consent)). When omitted, the pixel behaves normally. [see more](https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/)
+
+### GDPR consent
+Meta's `consent` is a **global** setting (it takes no pixel id), so it applies to every configured pixel. To stay GDPR compliant, set `consent: 'revoke'` on a pixel so the module revokes **before** initialization — nothing is sent to Meta until you grant consent:
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  modules: ['nuxt-meta-pixel'],
+  runtimeConfig: {
+    public: {
+      metapixel: {
+        default: { id: '1176370652884847', consent: 'revoke' },
+      }
+    }
+  }
+})
+```
+
+Then grant (or re-revoke) consent at runtime once your cookie banner is answered, via the injected `$fbq`:
+
+```html
+<script setup lang="ts">
+const { $fbq } = useNuxtApp()
+
+function onCookieBannerAccepted() {
+  $fbq('consent', 'grant')
+}
+
+function onCookieBannerRejected() {
+  $fbq('consent', 'revoke')
+}
+</script>
+```
+
+> Note: on a classic multi-page (non-SPA) site Meta requires calling `revoke` on every page load — the module handles this by revoking on plugin init. [see more](https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/)
 
 ### Environment variables
 ```env
@@ -88,6 +124,7 @@ onMounted(() => {
 - [Conversion Tracking](https://developers.facebook.com/docs/meta-pixel/implementation/conversion-tracking/?locale=fr_FR)
 - [Events](https://developers.facebook.com/docs/meta-pixel/reference/)
 - [Accurate Event Tracking with Multiple Pixels](https://developers.facebook.com/ads/blog/post/v2/2017/11/28/event-tracking-with-multiple-pixels-tracksingle/)
+- [GDPR consent](https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/)
 
 
 ## Contribution

--- a/packages/nuxt-meta-pixel/README.md
+++ b/packages/nuxt-meta-pixel/README.md
@@ -53,10 +53,15 @@ export default defineNuxtConfig({
 - **id** `string` - your pixel id
 - **autoconfig** `boolean` (default: `true`) - enable or disable pixel autoconfig. [see more](https://developers.facebook.com/docs/meta-pixel/advanced/?locale=fr_FR)
 - **pageView** `string` (default: `**`) - glob expression to decide which route or not should send a PageView event automatically. [see more](https://www.npmjs.com/package/minimatch)
-- **consent** `'grant' | 'revoke'` - GDPR consent. Set `revoke` to hold event delivery until the user opts in (see [GDPR consent](#gdpr-consent)). When omitted, the pixel behaves normally. [see more](https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/)
+- **consent** `'revoke'` - opt into GDPR consent gating. Set `revoke` to hold event delivery until the user opts in (see [GDPR consent](#gdpr-consent)). When omitted, the pixel behaves normally. [see more](https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/)
 
 ### GDPR consent
-Meta's `consent` is a **global** setting (it takes no pixel id), so it applies to every configured pixel. To stay GDPR compliant, set `consent: 'revoke'` on a pixel so the module revokes **before** initialization — nothing is sent to Meta until you grant consent:
+Meta's `consent` is a **global** setting — the command takes no pixel id, so it applies to **every** pixel at once. Concretely:
+
+- Setting `consent: 'revoke'` on **any** pixel revokes **all** pixels (the most restrictive value wins). You can't keep one pixel live while another is revoked.
+- `consent` in the config only meaningfully accepts `'revoke'` (opting into gating). Granting is done **at runtime** — tracking is allowed by default, so a config `'grant'` would be a no-op.
+
+To stay GDPR compliant, set `consent: 'revoke'` so the module revokes **before** initialization — nothing is sent to Meta until you grant consent:
 
 ```ts
 // nuxt.config.ts

--- a/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
+++ b/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
@@ -6,8 +6,15 @@ import type { Plugin } from 'nuxt/app'
 export default defineNuxtPlugin(() => {
   const runtimeConfig = useRuntimeConfig()
   const pixels = runtimeConfig.public.metapixel
-  const { $fbq, init, pageView } = setup()
+  const { $fbq, init, pageView, consent } = setup()
   $fbq.disablePushState = true
+
+  // `consent` is a global Meta setting (not per-pixel). Revoke once before any
+  // init if a pixel opts into GDPR gating, so nothing is sent until the app
+  // later calls `$fbq('consent', 'grant')`.
+  if (Object.values(pixels).some(pixel => pixel.consent === 'revoke')) {
+    consent('revoke')
+  }
 
   for (const name in pixels) {
     const pixel = pixels[name]

--- a/packages/nuxt-meta-pixel/src/typings.ts
+++ b/packages/nuxt-meta-pixel/src/typings.ts
@@ -1,5 +1,14 @@
+import type { Consent } from 'meta-pixel'
+
 export interface Pixel {
   id: number | string
+  /**
+   * GDPR consent for the Meta Pixel. Set `revoke` to hold all event delivery
+   * until you call `$fbq('consent', 'grant')` (e.g. after a cookie banner is
+   * accepted). Consent is a global Meta setting, so it applies to every pixel.
+   * @see https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/
+   */
+  consent?: Consent
   autoconfig?: boolean
   pageView?: string
 }

--- a/packages/nuxt-meta-pixel/src/typings.ts
+++ b/packages/nuxt-meta-pixel/src/typings.ts
@@ -1,14 +1,16 @@
-import type { Consent } from 'meta-pixel'
-
 export interface Pixel {
   id: number | string
   /**
-   * GDPR consent for the Meta Pixel. Set `revoke` to hold all event delivery
-   * until you call `$fbq('consent', 'grant')` (e.g. after a cookie banner is
-   * accepted). Consent is a global Meta setting, so it applies to every pixel.
+   * Opt into GDPR consent gating. Set `'revoke'` to hold event delivery until
+   * you grant consent at runtime via `$fbq('consent', 'grant')` (e.g. after a
+   * cookie banner is accepted).
+   *
+   * Consent is a GLOBAL Meta setting (the command takes no pixel id): revoking
+   * on any pixel holds *every* configured pixel, not just this one. Granting is
+   * runtime-only, so `'grant'` is not a valid config value.
    * @see https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/
    */
-  consent?: Consent
+  consent?: 'revoke'
   autoconfig?: boolean
   pageView?: string
 }

--- a/packages/nuxt-meta-pixel/test/consent.test.ts
+++ b/packages/nuxt-meta-pixel/test/consent.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { setup, type FacebookQuery } from 'meta-pixel'
+
+function mockFbq() {
+  const calls: unknown[][] = []
+  const fbq = ((...args: unknown[]) => {
+    calls.push(args)
+  }) as unknown as FacebookQuery
+  return { fbq, calls }
+}
+
+describe('consent', () => {
+  it('issues the global consent command (no pixel id)', () => {
+    const { fbq, calls } = mockFbq()
+    setup(fbq).consent('revoke')
+    expect(calls).toContainEqual(['consent', 'revoke'])
+  })
+
+  it('revokes before init so nothing is sent until granted', () => {
+    const { fbq, calls } = mockFbq()
+    setup(fbq).consent('revoke').init('123', true)
+
+    const consentIdx = calls.findIndex(c => c[0] === 'consent')
+    const initIdx = calls.findIndex(c => c[0] === 'init')
+    expect(consentIdx).toBeGreaterThanOrEqual(0)
+    expect(consentIdx).toBeLessThan(initIdx)
+  })
+
+  it('does not touch consent when never called (backward compatible)', () => {
+    const { fbq, calls } = mockFbq()
+    setup(fbq).init('123', true)
+    expect(calls.some(c => c[0] === 'consent')).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #18. Reworked from @robbievolt's #22 — same goal and Meta-official mechanism, with the consent semantics corrected against the [GDPR docs](https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/).

## What it adds

- **`meta-pixel`**: a dedicated `setup().consent('grant' | 'revoke')` method (typed `Consent`) and the `('consent', …)` command on `FacebookQuery`.
- **`nuxt-meta-pixel`**: an optional per-pixel `consent?: 'grant' | 'revoke'` config field. When any pixel opts into gating, the plugin revokes **once before** initializing pixels — so nothing is sent to Meta until you grant.
- Runtime grant via the injected `$fbq('consent', 'grant')` after the cookie banner is answered.
- README "GDPR consent" section + a unit test.

## Why not merge #22 as-is

I verified the behaviour against Meta's GDPR doc. Corrections vs #22:

1. **Consent is GLOBAL, not per-pixel.** The documented command (`fbq('consent', 'revoke')`) takes **no pixel id**. #22 called it per pixel inside `init()` in a loop, so with multiple pixels a later pixel's value would silently override an earlier one. Here it's issued **once** before the init loop.
2. **Order is enforced & tested.** The doc requires `revoke` *before* `init`; a unit test asserts that ordering.
3. **Typed `'grant' | 'revoke'`** instead of loose `string`, in the command, the `Setup` method and the Pixel config.
4. **Fixes the `$fbq('constent', …)` typo** from #22's README example.
5. **Backward compatible**: consent is only touched when explicitly configured (#22 issued `grant` on every init by default).

> Doc nuance I could not confirm and therefore don't claim: whether `revoke` prevents `fbevents.js` from loading. The doc only states it *"pauses sending Pixel fires"*. The README reflects exactly that.

## Verification (Node 22.15)

- `yarn lint` → 0/0 ✅
- `yarn test` → **10/10** ✅ (3 new consent tests, incl. revoke-before-init ordering)
- `yarn prepack` ✅ · `yarn dev:build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)