### PR TITLE
chore: release meta-pixel@1.2.0 & nuxt-meta-pixel@2.1.0

### DIFF
--- a/packages/meta-pixel/CHANGELOG.md
+++ b/packages/meta-pixel/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## v1.2.0
+
+### Added
+- GDPR consent support: a new `setup().consent('grant' | 'revoke')` method, the
+  exported `Consent` type, and the `('consent', …)` command on `FacebookQuery`.
+  Call `consent('revoke')` before `init` to hold event delivery, then
+  `consent('grant')` once the user opts in. ([#18](https://github.com/tanukijs/meta-pixel/issues/18))
+
+## v1.1.0
+- Initial published baseline.

--- a/packages/meta-pixel/package.json
+++ b/packages/meta-pixel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-pixel",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "author": "tanukijs <tanuki.contact@gmail.com>",
   "description": "Wrapper for meta pixels",

--- a/packages/nuxt-meta-pixel/CHANGELOG.md
+++ b/packages/nuxt-meta-pixel/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+## v2.1.0
+
+### Added
+- **GDPR consent** ([#18](https://github.com/tanukijs/meta-pixel/issues/18)): opt
+  into consent gating with a per-pixel `consent: 'revoke'` config field. The
+  module revokes globally before init, so nothing is sent to Meta until you
+  grant at runtime via `$fbq('consent', 'grant')` (e.g. after a cookie banner).
+  Consent is a global Meta setting, so revoking on any pixel holds every pixel.
+
+### Fixed
+- Replace `minimatch` with a built-in glob matcher, removing the
+  `brace-expansion` ESM-interop crash in Vite dev on recent Nuxt versions
+  ([#14](https://github.com/tanukijs/meta-pixel/issues/14), [#20](https://github.com/tanukijs/meta-pixel/issues/20)).
+- Resolve `#imports` in the published runtime and drop the `#vue-router` import,
+  fixing `Failed to resolve import "#vue-router"` from consuming apps
+  ([#12](https://github.com/tanukijs/meta-pixel/issues/12)).
+
+### Changed
+- Update to the latest Nuxt 3 line (3.21) and `@nuxt/module-builder` 1.x. The
+  module is now **ESM-only** (no more `module.cjs` / `require` entry), as
+  required for Nuxt v3+. Requires Node ≥ 22.
+- Migrate linting to the ESLint 9 flat config.
+- Bump the `meta-pixel` dependency to `^1.2.0` for the new consent API.
+
+## v2.0.2
+- Previous published release.

--- a/packages/nuxt-meta-pixel/package.json
+++ b/packages/nuxt-meta-pixel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-meta-pixel",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "license": "MIT",
   "author": "tanukijs <tanuki.contact@gmail.com>",
   "description": "Nuxt best module to use Facebook's pixels in your application.",
@@ -51,7 +51,7 @@
   "dependencies": {
     "@nuxt/kit": "^3.21.6",
     "defu": "^6.1.7",
-    "meta-pixel": "^1.1.0"
+    "meta-pixel": "^1.2.0"
   },
   "devDependencies": {
     "@nuxt/devtools": "^2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7422,7 +7422,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"meta-pixel@npm:^1.1.0, meta-pixel@workspace:packages/meta-pixel":
+"meta-pixel@npm:^1.2.0, meta-pixel@workspace:packages/meta-pixel":
   version: 0.0.0-use.local
   resolution: "meta-pixel@workspace:packages/meta-pixel"
   dependencies:
@@ -8032,7 +8032,7 @@ __metadata:
     changelogen: "npm:^0.6.2"
     defu: "npm:^6.1.7"
     eslint: "npm:^9.39.4"
-    meta-pixel: "npm:^1.1.0"
+    meta-pixel: "npm:^1.2.0"
     nuxt: "npm:^3.21.6"
     typescript: "npm:^5.9.3"
     vitest: "npm:^4.1.6"


### PR DESCRIPTION
Version bump for everything merged since the last publish (`nuxt-meta-pixel@2.0.2` / `meta-pixel@1.1.0`). **No publish is performed here** — this only prepares versions, the `meta-pixel` dependency floor, and changelogs.

## Versions

| Package | From | To | Why |
|---|---|---|---|
| `meta-pixel` | 1.1.0 | **1.2.0** | new `consent()` API (additive) |
| `nuxt-meta-pixel` | 2.0.2 | **2.1.0** | GDPR consent + fixes + Nuxt 3.21 toolchain |

Also bumps `nuxt-meta-pixel`'s `meta-pixel` dependency floor `^1.1.0 → ^1.2.0` (the plugin now calls `setup().consent()`), and adds `CHANGELOG.md` to both packages.

## What's in `nuxt-meta-pixel@2.1.0`

- **Added**: GDPR consent (#18) — per-pixel `consent: 'revoke'` + runtime `$fbq('consent', 'grant')`.
- **Fixed**: `brace-expansion` Vite crash (#14, #20); `#vue-router` resolution from consumers (#12).
- **Changed**: Nuxt 3.21 + module-builder 1.x → **ESM-only** (no more CJS `require` entry); ESLint 9 flat config; **requires Node ≥ 22**.

> Both are **minor** bumps. The ESM-only packaging change is technically a drop of the CJS `require` entry, but Nuxt v3+ loads modules as ESM and `@nuxt/module-builder` 1.x mandates it, so it's treated as non-breaking per Nuxt convention. The planned consent config restructure (per-pixel → global) remains a **future major**.

## Verification (Node 22.15)

- `yarn lint` → 0/0 ✅ · `yarn test` → 10/10 ✅ · `yarn prepack` ✅ (both packages build)

## After merge — to publish
From each package (or via the existing `release` script): `npm publish`. `meta-pixel` must be published **before** `nuxt-meta-pixel` (the floor is `^1.2.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)