### PR TITLE
feat!: restructure config — global consent + nested pixels (BREAKING)

### DIFF
--- a/packages/nuxt-meta-pixel/README.md
+++ b/packages/nuxt-meta-pixel/README.md
@@ -40,28 +40,35 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       metapixel: {
-        default: { id: '1176370652884847', pageView: '/posts/**' },
-        ads01: { id: '415215247513663' },
-        ads02: { id: '415215247513664', pageView: '!/posts/**' },
+        pixels: {
+          default: { id: '1176370652884847', pageView: '/posts/**' },
+          ads01: { id: '415215247513663' },
+          ads02: { id: '415215247513664', pageView: '!/posts/**' },
+        }
       }
     }
   }
 })
 ```
 
+> **Breaking change in v3:** pixels are now nested under `metapixel.pixels`, and `consent` moved to a top-level (global) option. Previously pixels lived directly under `metapixel`.
+
+#### Module options
+- **consent** `'revoke'` - opt into GDPR consent gating, applied to **all** pixels (see [GDPR consent](#gdpr-consent)). When omitted, pixels behave normally. [see more](https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/)
+- **pixels** `Record<string, Pixel>` - the pixels to load, keyed by an arbitrary name.
+
 #### Pixel options
 - **id** `string` - your pixel id
 - **autoconfig** `boolean` (default: `true`) - enable or disable pixel autoconfig. [see more](https://developers.facebook.com/docs/meta-pixel/advanced/?locale=fr_FR)
 - **pageView** `string` (default: `**`) - glob expression to decide which route or not should send a PageView event automatically. [see more](https://www.npmjs.com/package/minimatch)
-- **consent** `'revoke'` - opt into GDPR consent gating. Set `revoke` to hold event delivery until the user opts in (see [GDPR consent](#gdpr-consent)). When omitted, the pixel behaves normally. [see more](https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/)
 
 ### GDPR consent
-Meta's `consent` is a **global** setting — the command takes no pixel id, so it applies to **every** pixel at once. Concretely:
+Meta's `consent` is a **global** setting — the command takes no pixel id, so it applies to **every** pixel at once. It's therefore a single top-level option, not per-pixel:
 
-- Setting `consent: 'revoke'` on **any** pixel revokes **all** pixels (the most restrictive value wins). You can't keep one pixel live while another is revoked.
-- `consent` in the config only meaningfully accepts `'revoke'` (opting into gating). Granting is done **at runtime** — tracking is allowed by default, so a config `'grant'` would be a no-op.
+- `consent: 'revoke'` holds **all** pixels until you grant consent.
+- The config only accepts `'revoke'` (opting into gating). Granting is done **at runtime** — tracking is allowed by default, so a config `'grant'` would be a no-op.
 
-To stay GDPR compliant, set `consent: 'revoke'` so the module revokes **before** initialization — nothing is sent to Meta until you grant consent:
+Set `consent: 'revoke'` so the module revokes **before** initialization — nothing is sent to Meta until you grant consent:
 
 ```ts
 // nuxt.config.ts
@@ -70,7 +77,10 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       metapixel: {
-        default: { id: '1176370652884847', consent: 'revoke' },
+        consent: 'revoke',
+        pixels: {
+          default: { id: '1176370652884847' },
+        }
       }
     }
   }
@@ -99,9 +109,9 @@ function onCookieBannerRejected() {
 ```env
 // .env
 // This example show how to define pixel ids via your environment variables
-NUXT_PUBLIC_METAPIXEL_DEFAULT_ID=ID1
-NUXT_PUBLIC_METAPIXEL_ADS01_ID=ID2
-NUXT_PUBLIC_METAPIXEL_ADS02_ID=ID3
+NUXT_PUBLIC_METAPIXEL_PIXELS_DEFAULT_ID=ID1
+NUXT_PUBLIC_METAPIXEL_PIXELS_ADS01_ID=ID2
+NUXT_PUBLIC_METAPIXEL_PIXELS_ADS02_ID=ID3
 ```
 
 The variable you are trying to update via an environment variable must be defined in your `nuxt.config.ts`. Replace `DEFAULT`, `ADS01` or `ADS02` by the names you defined.

--- a/packages/nuxt-meta-pixel/playground/nuxt.config.ts
+++ b/packages/nuxt-meta-pixel/playground/nuxt.config.ts
@@ -1,9 +1,12 @@
 export default defineNuxtConfig({
   modules: ['../src/module'],
   metapixel: {
-    default: { id: '1176370652884847', pageView: '/posts/**' },
-    test01: { id: '415215247513663' },
-    test02: { id: '415215247513664', pageView: '!/posts/**' },
+    consent: 'revoke',
+    pixels: {
+      default: { id: '1176370652884847', pageView: '/posts/**' },
+      test01: { id: '415215247513663' },
+      test02: { id: '415215247513664', pageView: '!/posts/**' },
+    },
   },
   devtools: { enabled: true }
 })

--- a/packages/nuxt-meta-pixel/src/module.ts
+++ b/packages/nuxt-meta-pixel/src/module.ts
@@ -13,6 +13,9 @@ export default defineNuxtModule<ModuleOptions>({
     name: 'nuxt-meta-pixel',
     configKey: 'metapixel'
   },
+  defaults: {
+    pixels: {}
+  },
   setup (options, nuxt) {
     const resolver = createResolver(import.meta.url)
 

--- a/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
+++ b/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
@@ -4,15 +4,13 @@ import { matchPath } from './glob'
 import type { Plugin } from 'nuxt/app'
 
 export default defineNuxtPlugin(() => {
-  const runtimeConfig = useRuntimeConfig()
-  const pixels = runtimeConfig.public.metapixel
+  const { consent: globalConsent, pixels } = useRuntimeConfig().public.metapixel
   const { $fbq, init, pageView, consent } = setup()
   $fbq.disablePushState = true
 
-  // `consent` is a global Meta setting (not per-pixel). Revoke once before any
-  // init if a pixel opts into GDPR gating, so nothing is sent until the app
-  // later calls `$fbq('consent', 'grant')`.
-  if (Object.values(pixels).some(pixel => pixel.consent === 'revoke')) {
+  // `consent` is a global Meta setting. Revoke before any init when configured,
+  // so nothing is sent until the app later calls `$fbq('consent', 'grant')`.
+  if (globalConsent === 'revoke') {
     consent('revoke')
   }
 

--- a/packages/nuxt-meta-pixel/src/typings.ts
+++ b/packages/nuxt-meta-pixel/src/typings.ts
@@ -1,20 +1,19 @@
 export interface Pixel {
   id: number | string
-  /**
-   * Opt into GDPR consent gating. Set `'revoke'` to hold event delivery until
-   * you grant consent at runtime via `$fbq('consent', 'grant')` (e.g. after a
-   * cookie banner is accepted).
-   *
-   * Consent is a GLOBAL Meta setting (the command takes no pixel id): revoking
-   * on any pixel holds *every* configured pixel, not just this one. Granting is
-   * runtime-only, so `'grant'` is not a valid config value.
-   * @see https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/
-   */
-  consent?: 'revoke'
   autoconfig?: boolean
   pageView?: string
 }
 
 export interface ModuleOptions {
-  [name: string]: Pixel
+  /**
+   * GDPR consent, applied globally to every pixel (the Meta `consent` command
+   * takes no pixel id). Set `'revoke'` to hold all event delivery until you
+   * grant consent at runtime via `$fbq('consent', 'grant')` (e.g. after a
+   * cookie banner is accepted). Granting is runtime-only, so `'grant'` is not a
+   * valid config value (tracking is allowed by default).
+   * @see https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/
+   */
+  consent?: 'revoke'
+  /** Pixels to load, keyed by an arbitrary name. */
+  pixels: Record<string, Pixel>
 }


### PR DESCRIPTION
First breaking change for the upcoming **major (v3, still Nuxt 3)**: restructure the module config so `consent` is a proper **global** option and pixels live under a `pixels` key.

## Breaking change

```diff
 metapixel: {
-  default: { id: '123', pageView: '/posts/**', consent: 'revoke' },
-  ads01:   { id: '456' },
+  consent: 'revoke',
+  pixels: {
+    default: { id: '123', pageView: '/posts/**' },
+    ads01:   { id: '456' },
+  },
 }
```

- **`consent` moved to top-level (global).** Meta's `consent` command takes no pixel id, so it's inherently global — modelling it per-pixel implied control that doesn't exist. It now lives once at the root.
- **Pixels nested under `pixels`.** This frees the root namespace for global options (and the upcoming `enabled` toggle in a follow-up PR).
- **Env-var overrides change**: `NUXT_PUBLIC_METAPIXEL_<NAME>_ID` → `NUXT_PUBLIC_METAPIXEL_PIXELS_<NAME>_ID`.

No legacy/migration shim — clean break, as agreed.

## Changes
- `ModuleOptions` is now `{ consent?: 'revoke', pixels: Record<string, Pixel> }`; `consent` removed from `Pixel`.
- Plugin reads the global `consent` and the nested `pixels`; module defaults `pixels` to `{}`.
- Playground config + README (config example, options split into Module/Pixel, GDPR section, env vars) updated.

## Follow-up
- Separate PR: global `enabled` toggle (#16/#15).
- The `3.0.0` version bump will be a dedicated release PR once both land.

## Verification (Node 22.15)
- `yarn lint` 0/0 ✅ · `yarn test` 10/10 ✅ · `yarn prepack` ✅ · `yarn dev:build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)