### PR TITLE
feat: add global `enabled` toggle to disable the module (#16, #15)

### DIFF
--- a/packages/nuxt-meta-pixel/README.md
+++ b/packages/nuxt-meta-pixel/README.md
@@ -54,8 +54,31 @@ export default defineNuxtConfig({
 > **Breaking change in v3:** pixels are now nested under `metapixel.pixels`, and `consent` moved to a top-level (global) option. Previously pixels lived directly under `metapixel`.
 
 #### Module options
+- **enabled** `boolean` (default: `true`) - when `false`, the module loads and sends nothing, but still provides a no-op `$fbq` so your components keep working (see [Disable outside production](#disable-outside-production)).
 - **consent** `'revoke'` - opt into GDPR consent gating, applied to **all** pixels (see [GDPR consent](#gdpr-consent)). When omitted, pixels behave normally. [see more](https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/)
 - **pixels** `Record<string, Pixel>` - the pixels to load, keyed by an arbitrary name.
+
+### Disable outside production
+Set `enabled` to `false` to avoid loading the pixel (e.g. in development or staging) without conditionally registering the module — your components can still call `$fbq` safely, it just does nothing:
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  modules: ['nuxt-meta-pixel'],
+  runtimeConfig: {
+    public: {
+      metapixel: {
+        enabled: process.env.NODE_ENV === 'production',
+        pixels: {
+          default: { id: '1176370652884847' },
+        }
+      }
+    }
+  }
+})
+```
+
+You can also flip it at runtime with the `NUXT_PUBLIC_METAPIXEL_ENABLED` environment variable.
 
 #### Pixel options
 - **id** `string` - your pixel id

--- a/packages/nuxt-meta-pixel/src/module.ts
+++ b/packages/nuxt-meta-pixel/src/module.ts
@@ -14,6 +14,7 @@ export default defineNuxtModule<ModuleOptions>({
     configKey: 'metapixel'
   },
   defaults: {
+    enabled: true,
     pixels: {}
   },
   setup (options, nuxt) {

--- a/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
+++ b/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
@@ -4,7 +4,15 @@ import { matchPath } from './glob'
 import type { Plugin } from 'nuxt/app'
 
 export default defineNuxtPlugin(() => {
-  const { consent: globalConsent, pixels } = useRuntimeConfig().public.metapixel
+  const { enabled = true, consent: globalConsent, pixels } = useRuntimeConfig().public.metapixel
+
+  // When disabled, load and send nothing — but still provide a no-op `$fbq` so
+  // components calling it (e.g. `$fbq('track', …)`) keep working everywhere.
+  if (!enabled) {
+    const noop = (() => {}) as unknown as FacebookQuery
+    return { provide: { fbq: noop } }
+  }
+
   const { $fbq, init, pageView, consent } = setup()
   $fbq.disablePushState = true
 

--- a/packages/nuxt-meta-pixel/src/typings.ts
+++ b/packages/nuxt-meta-pixel/src/typings.ts
@@ -6,6 +6,13 @@ export interface Pixel {
 
 export interface ModuleOptions {
   /**
+   * When `false`, the module loads and sends nothing, but still provides a
+   * no-op `$fbq` so components calling it keep working. Handy to disable
+   * tracking outside production without conditionally registering the module.
+   * Override at runtime with `NUXT_PUBLIC_METAPIXEL_ENABLED`. Default `true`.
+   */
+  enabled?: boolean
+  /**
    * GDPR consent, applied globally to every pixel (the Meta `consent` command
    * takes no pixel id). Set `'revoke'` to hold all event delivery until you
    * grant consent at runtime via `$fbq('consent', 'grant')` (e.g. after a


### PR DESCRIPTION
Second piece of the v3 major: a global `enabled` toggle. Addresses #16 (production-only) and revives the intent of the closed #15.

> ⛓️ **Stacked on #30** (the config restructure). Base is `feat/config-restructure-consent`. **Merge #30 first**, then this PR's base should be retargeted to `dev` (or merge #30 into dev and rebase). I can retarget it once #30 lands.

## What it adds

`enabled?: boolean` (default `true`) at the top level:

```ts
metapixel: {
  enabled: process.env.NODE_ENV === 'production',
  pixels: { default: { id: '123' } },
}
```

When `false`, the plugin loads and sends **nothing** — but still provides a **no-op `$fbq`**. That's the key DX win over conditionally registering the module: `useNuxtApp().$fbq('track', …)` keeps working in every environment instead of crashing where the module isn't registered.

- Overridable at runtime via `NUXT_PUBLIC_METAPIXEL_ENABLED`.
- `enabled` vs `consent`: `enabled: false` loads nothing (operational/env switch); `consent: 'revoke'` still loads `fbevents.js` but pauses sending (legal/user consent).

## Changes
- `ModuleOptions.enabled?: boolean`; module `defaults` includes `enabled: true`.
- Plugin early-returns a no-op `$fbq` when disabled.
- README "Disable outside production" section.

## Verification (Node 22.15)
- `yarn lint` 0/0 ✅ · `yarn test` 10/10 ✅ · `yarn prepack` ✅ · `yarn dev:build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)