### PR TITLE
feat: dynamic pixel init via useMetaPixel() composable (#21)

### DIFF
--- a/packages/meta-pixel/src/meta-pixel.ts
+++ b/packages/meta-pixel/src/meta-pixel.ts
@@ -1,4 +1,4 @@
-import type { Consent, FacebookQuery, Setup } from './typings'
+import type { Consent, FacebookQuery, InitData, Setup } from './typings'
 
 export * from './typings'
 
@@ -46,9 +46,9 @@ export function setup($fbq: FacebookQuery = addScriptDefault()): Setup {
     return setup($fbq)
   }
 
-  function init (pixelId: string, autoconfig: boolean = true) {
+  function init (pixelId: string, autoconfig: boolean = true, data?: InitData) {
     $fbq('set', 'autoConfig', autoconfig, pixelId)
-    $fbq('init', pixelId)
+    $fbq('init', pixelId, data)
     return setup($fbq)
   }
   

--- a/packages/meta-pixel/src/typings.ts
+++ b/packages/meta-pixel/src/typings.ts
@@ -12,7 +12,7 @@ interface EventOptions {
   value?: number
 }
 
-type InitData = {
+export type InitData = {
   em?: string
   fn?: string
   ln?: string
@@ -82,7 +82,7 @@ export interface FacebookQuery {
 export interface Setup {
   $fbq: FacebookQuery
   consent(consent: Consent): Setup
-  init(pixelId: string, autoconfig?: boolean): Setup
+  init(pixelId: string, autoconfig?: boolean, data?: InitData): Setup
   pageView(pixelId?: string): Setup
 }
 

--- a/packages/nuxt-meta-pixel/README.md
+++ b/packages/nuxt-meta-pixel/README.md
@@ -158,6 +158,35 @@ onMounted(() => {
 </template>
 ```
 
+### Dynamic initialization
+When your pixel IDs aren't known at build time — multi-tenant apps, IDs stored in a database or CMS — initialize them at runtime with the `useMetaPixel()` composable, after fetching your settings:
+
+```html
+<script setup lang="ts">
+const { init, $fbq } = useMetaPixel()
+
+const settings = await fetchTenantSettings()
+
+// Initialize and register the pixel; `pageView` opts it into automatic
+// route tracking (and fires a PageView now if the current route matches).
+init(settings.pixelId, {
+  advancedMatching: { em: 'user@example.com' },
+  pageView: '/shop/**',
+})
+
+// $fbq is the same instance used by config pixels
+$fbq('track', 'ViewContent')
+</script>
+```
+
+`useMetaPixel()` exposes `{ $fbq, init, pageView, consent }`. It is always safe to call: on the server (or when `enabled` is `false`) it returns a no-op controller.
+
+#### `init(id, options?)`
+- **id** `string | number` - the pixel id to initialize.
+- **options.autoConfig** `boolean` (default: `true`) - enable Meta's automatic configuration.
+- **options.advancedMatching** `InitData` - advanced matching data passed to `fbq('init', id, data)`.
+- **options.pageView** `string` (default: `**`) - glob deciding which routes auto-send a `PageView` for this pixel.
+
 ## Useful resources
 - [Conversion Tracking](https://developers.facebook.com/docs/meta-pixel/implementation/conversion-tracking/?locale=fr_FR)
 - [Events](https://developers.facebook.com/docs/meta-pixel/reference/)

--- a/packages/nuxt-meta-pixel/src/module.ts
+++ b/packages/nuxt-meta-pixel/src/module.ts
@@ -1,4 +1,4 @@
-import { addPlugin, createResolver, defineNuxtModule } from '@nuxt/kit'
+import { addImports, addPlugin, createResolver, defineNuxtModule } from '@nuxt/kit'
 import { defu } from 'defu'
 import type { ModuleOptions } from './typings'
 
@@ -30,6 +30,11 @@ export default defineNuxtModule<ModuleOptions>({
     // consumer's Vite may pre-bundle the runtime from node_modules and fail to
     // resolve the alias (#12).
     nuxt.options.build.transpile.push(resolver.resolve('./runtime'))
+
+    addImports({
+      name: 'useMetaPixel',
+      from: resolver.resolve('./runtime/composables')
+    })
 
     addPlugin(resolver.resolve('./runtime/plugin.client'))
   }

--- a/packages/nuxt-meta-pixel/src/runtime/composables.ts
+++ b/packages/nuxt-meta-pixel/src/runtime/composables.ts
@@ -1,0 +1,31 @@
+import { useNuxtApp } from '#imports'
+import type { FacebookQuery } from 'meta-pixel'
+import type { MetaPixelController } from '../typings'
+
+/** A controller that does nothing — used on the server and when disabled. */
+export function createNoopController(): MetaPixelController {
+  const noop = (() => {}) as unknown as FacebookQuery
+  return {
+    $fbq: noop,
+    init: () => {},
+    pageView: () => {},
+    consent: () => {}
+  }
+}
+
+/**
+ * Access the Meta Pixel runtime API. Lets you initialize pixels dynamically —
+ * e.g. after fetching a tenant's settings from an API:
+ *
+ * ```ts
+ * const { init, $fbq } = useMetaPixel()
+ * const settings = await fetchSettings()
+ * init(settings.pixelId, { advancedMatching: { em }, pageView: '/shop/**' })
+ * ```
+ *
+ * On the server (or when the module is disabled) it returns a no-op controller,
+ * so it is always safe to call.
+ */
+export function useMetaPixel(): MetaPixelController {
+  return useNuxtApp().$metaPixel ?? createNoopController()
+}

--- a/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
+++ b/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
@@ -1,16 +1,18 @@
 import { defineNuxtPlugin, useRouter, useRuntimeConfig } from '#imports'
-import { setup, type FacebookQuery } from 'meta-pixel'
+import { setup, type FacebookQuery, type InitData } from 'meta-pixel'
 import { matchPath } from './glob'
+import { createNoopController } from './composables'
+import type { MetaPixelController } from '../typings'
 import type { Plugin } from 'nuxt/app'
 
 export default defineNuxtPlugin(() => {
   const { enabled = true, consent: globalConsent, pixels } = useRuntimeConfig().public.metapixel
 
-  // When disabled, load and send nothing — but still provide a no-op `$fbq` so
-  // components calling it (e.g. `$fbq('track', …)`) keep working everywhere.
+  // When disabled, load and send nothing — but still provide a no-op `$fbq`
+  // and controller so components keep working everywhere.
   if (!enabled) {
-    const noop = (() => {}) as unknown as FacebookQuery
-    return { provide: { fbq: noop } }
+    const noop = createNoopController()
+    return { provide: { fbq: noop.$fbq, metaPixel: noop } }
   }
 
   const { $fbq, init, pageView, consent } = setup()
@@ -22,27 +24,51 @@ export default defineNuxtPlugin(() => {
     consent('revoke')
   }
 
+  // Live registry of pixels eligible for automatic route PageView — seeded from
+  // config and extended at runtime through `useMetaPixel().init`.
+  const tracked: { id: string, pageView: string }[] = []
+
+  function register(id: string, autoConfig: boolean | undefined, advancedMatching: InitData | undefined, pageViewGlob: string) {
+    init(id, autoConfig ?? true, advancedMatching)
+    tracked.push({ id, pageView: pageViewGlob })
+  }
+
   for (const name in pixels) {
     const pixel = pixels[name]
-    init(pixel.id.toString(), pixel.autoconfig)
+    register(pixel.id.toString(), pixel.autoconfig, undefined, pixel.pageView ?? '**')
   }
 
   const router = useRouter()
   router.afterEach((to, _, failure) => {
     if (failure) return
 
-    for (const name in pixels) {
-      const pixel = pixels[name]
-      const match = matchPath(to.path, pixel.pageView ?? '**')
-      if (match) {
-        pageView(pixel.id.toString())
+    for (const { id, pageView: glob } of tracked) {
+      if (matchPath(to.path, glob)) {
+        pageView(id)
       }
     }
   })
 
+  const controller: MetaPixelController = {
+    $fbq,
+    pageView,
+    consent,
+    init(id, options = {}) {
+      const idStr = id.toString()
+      const glob = options.pageView ?? '**'
+      register(idStr, options.autoConfig, options.advancedMatching, glob)
+      // The initial navigation has already happened by the time a runtime init
+      // runs, so fire a PageView immediately if the current route matches.
+      if (matchPath(router.currentRoute.value.path, glob)) {
+        pageView(idStr)
+      }
+    }
+  }
+
   return {
     provide: {
-      fbq: $fbq
+      fbq: $fbq,
+      metaPixel: controller
     }
-  } 
-}) as Plugin<{fbq: FacebookQuery}>
+  }
+}) as Plugin<{ fbq: FacebookQuery, metaPixel: MetaPixelController }>

--- a/packages/nuxt-meta-pixel/src/typings.ts
+++ b/packages/nuxt-meta-pixel/src/typings.ts
@@ -1,7 +1,35 @@
+import type { Consent, FacebookQuery, InitData } from 'meta-pixel'
+
 export interface Pixel {
   id: number | string
   autoconfig?: boolean
   pageView?: string
+}
+
+/** Options for initializing a pixel at runtime via `useMetaPixel().init`. */
+export interface InitOptions {
+  /** Enable Meta's automatic configuration. Default `true`. */
+  autoConfig?: boolean
+  /** Advanced matching data passed to `fbq('init', id, data)`. */
+  advancedMatching?: InitData
+  /**
+   * Glob deciding which routes auto-send a `PageView` for this pixel (same
+   * semantics as the config `pageView`). Default `'**'`. A `PageView` also
+   * fires immediately if the current route matches.
+   */
+  pageView?: string
+}
+
+/** Runtime API exposed by `useMetaPixel()` (and `$metaPixel`). */
+export interface MetaPixelController {
+  /** The underlying Facebook query function. */
+  $fbq: FacebookQuery
+  /** Initialize a pixel at runtime (e.g. after fetching settings from an API). */
+  init(id: string | number, options?: InitOptions): void
+  /** Send a `PageView`, optionally for a single pixel. */
+  pageView(pixelId?: string): void
+  /** Set the global GDPR consent. */
+  consent(consent: Consent): void
 }
 
 export interface ModuleOptions {

--- a/packages/nuxt-meta-pixel/test/init.test.ts
+++ b/packages/nuxt-meta-pixel/test/init.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { setup, type FacebookQuery } from 'meta-pixel'
+
+function mockFbq() {
+  const calls: unknown[][] = []
+  const fbq = ((...args: unknown[]) => {
+    calls.push(args)
+  }) as unknown as FacebookQuery
+  return { fbq, calls }
+}
+
+describe('init', () => {
+  it('passes advanced matching data to fbq init', () => {
+    const { fbq, calls } = mockFbq()
+    setup(fbq).init('123', true, { em: 'user@example.com' })
+    expect(calls).toContainEqual(['set', 'autoConfig', true, '123'])
+    expect(calls).toContainEqual(['init', '123', { em: 'user@example.com' }])
+  })
+
+  it('initializes without advanced matching when not provided', () => {
+    const { fbq, calls } = mockFbq()
+    setup(fbq).init('123')
+    expect(calls).toContainEqual(['init', '123', undefined])
+  })
+})


### PR DESCRIPTION
Closes #21. Lets apps initialize pixels **at runtime** — multi-tenant / CMS / DB-driven pixel IDs that aren't known at build time.

> ⛓️ **Stacked: depends on #30 and #31.** Base is `feat/enabled-toggle` (#31), which is itself on #30. Merge **#30 → #31 → this** in order. I can rebase/retarget once the parents land.

## API

```ts
const { init, $fbq } = useMetaPixel()

const settings = await fetchTenantSettings()
init(settings.pixelId, {
  advancedMatching: { em: 'user@example.com' },
  pageView: '/shop/**',   // opts into automatic route PageView
})
```

`useMetaPixel()` returns `{ $fbq, init, pageView, consent }`. It's always safe to call — on the server, or when `enabled: false`, it returns a no-op controller.

## How it works

- **meta-pixel** core: `init` now accepts optional advanced matching data (`fbq('init', id, data)`); the `InitData` type is exported. (additive)
- **nuxt-meta-pixel**: a **live pixel registry** seeded from config pixels and extended by runtime `init`. The `router.afterEach` iterates this registry, so dynamically-added pixels get automatic route-based PageView too. A runtime `init` also fires an immediate PageView if the current route matches (the initial navigation has already passed). Composable is auto-imported via `addImports`.

## Why a composable (vs the existing `$fbq`)

`$fbq('init', id)` was already possible, but it didn't integrate with the route-based PageView automation and lacked the `init`/`autoConfig` ergonomics. This closes that gap while reusing the same `$fbq` instance.

## Notes
- Additive / non-breaking. Targets the v3 line (could ship in 3.0.0 or a later 3.1.0 — release decision).
- `meta-pixel` core gains an additive `init` overload (→ a minor when released).

## Verification (Node 22.15)
- `yarn lint` 0/0 ✅ · `yarn test` **12/12** ✅ (2 new `init` tests) · `yarn prepack` ✅ · `yarn dev:build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)