### PR TITLE
fix: align meta-pixel types with Meta spec + add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+## What this is
+
+Yarn 4 monorepo (`packages/*`) shipping two published packages:
+
+- **`meta-pixel`** — framework-agnostic, **client-side only** TypeScript wrapper around Meta's `fbevents.js`. Builds with `tsc` to `lib/` (not committed). CJS (`main`/`types`), no `exports` field.
+- **`nuxt-meta-pixel`** — Nuxt 3 module wrapping `meta-pixel`. Built with `@nuxt/module-builder` to `dist/` (ESM).
+
+## Direction & conventions
+
+- Goal: keep both packages **fully functional on Nuxt 3**.
+- **One PR per fix** by default (small, focused branches off `dev`) — not catch-all branches.
+- `dev` is the integration/PR base branch; feature branches merge into it.
+- Released via `changelogen` (`npm run release` in each package); bump `meta-pixel` before the dependent `nuxt-meta-pixel`.
+- Toolchain pinned via Volta (Node 22.15.0, Yarn 4.2.1).
+
+## Meta Pixel semantics (verified against Meta docs — easy to get wrong)
+
+- `fbq('set', 'autoConfig', <boolean>, <pixelId>)` — **boolean before pixel id**.
+- **`consent` is global** (takes no pixel id): applies to every pixel. Must be `revoke`d **before** `init`, and re-`revoke`d on every page load. `'grant'` is runtime-only (tracking is on by default), so it's not a valid config value.
+- **Advanced matching fields are all strings** — including digit-only `ph` (e.g. `'16505554444'`) and `db` (YYYYMMDD, e.g. `'19910526'`).
+- `contents` is an **array of `{ id, quantity }`** (key is `id`, not `name`).
+- `Purchase` is the only standard event that **requires** `currency` + `value`.
+- CAPI deduplication: `eventID` is the **4th positional arg** — `fbq('track', 'Purchase', {...}, { eventID })`.
+- `pageView` globs use the in-house `runtime/glob.ts`, **not** minimatch — only `**`, `*`, `?`, leading `!` are supported (no `{a,b}` / `[abc]`). It replaced minimatch to dodge a `brace-expansion` ESM crash in Vite dev (#14, #20).
+
+## Common commands
+
+```bash
+# meta-pixel
+cd packages/meta-pixel && yarn build      # tsc --build
+
+# nuxt-meta-pixel
+cd packages/nuxt-meta-pixel
+npm run dev:prepare                        # generate type stubs (run first)
+npm run dev                                # playground
+npm run lint                               # eslint
+npm run test                               # vitest run
+```
+
+## Reference docs
+
+- Pixel events & parameters: https://developers.facebook.com/docs/meta-pixel/reference
+- Advanced matching: https://developers.facebook.com/docs/meta-pixel/advanced/advanced-matching
+- autoConfig / advanced: https://developers.facebook.com/docs/meta-pixel/advanced
+- GDPR consent: https://developers.facebook.com/docs/meta-pixel/implementation/gdpr
+- trackSingle (multi-pixel): https://developers.facebook.com/ads/blog/post/v2/2017/11/28/event-tracking-with-multiple-pixels-tracksingle/

--- a/packages/meta-pixel/README.md
+++ b/packages/meta-pixel/README.md
@@ -14,7 +14,7 @@
 import { addScriptDefault } from 'meta-pixel'
 
 const fbq = addScriptDefault()
-fbq('set', 'autoConfig', 'pixel_01', true)
+fbq('set', 'autoConfig', true, 'pixel_01')
 fbq('init', 'pixel_01')
 fbq('track', 'PageView')
 ```

--- a/packages/meta-pixel/src/typings.ts
+++ b/packages/meta-pixel/src/typings.ts
@@ -3,7 +3,9 @@ interface EventOptions {
   content_ids?: Array<string | number>
   content_name?: string
   content_type?: string
-  contents?: [{ name: string, quantity: number }]
+  // An array of items, each keyed by `id` (not `name`).
+  // @see https://developers.facebook.com/docs/meta-pixel/reference
+  contents?: Array<{ id: string, quantity: number }>
   currency?: string
   num_items?: number
   predicted_ltv?: number
@@ -12,14 +14,17 @@ interface EventOptions {
   value?: number
 }
 
+// Advanced matching. Every field is sent as a string — even digit-only ones
+// like `ph` (e.g. '16505554444') and `db` (YYYYMMDD, e.g. '19910526').
+// @see https://developers.facebook.com/docs/meta-pixel/advanced/advanced-matching
 type InitData = {
   em?: string
   fn?: string
   ln?: string
-  ph?: number
+  ph?: string
   external_id?: string
   ge?: '' | 'f' | 'm'
-  db?: number
+  db?: string
   ct?: string
   st?: string
   zp?: string


### PR DESCRIPTION
## Summary

Fixes three deviations from Meta's documented Pixel API in the `meta-pixel` package, each verified against the official docs, and adds a root `CLAUDE.md`.

### Type/doc fixes (`meta-pixel`)
- **`contents`** → `Array<{ id, quantity }>` instead of the one-element tuple `[{ name, quantity }]`. Meta expects an array of items keyed by `id`, not `name`. ([reference](https://developers.facebook.com/docs/meta-pixel/reference))
- **`ph` / `db`** → `string` instead of `number`. Advanced matching fields are all transmitted as strings; `number` drops leading zeros on phones and misrepresents the `YYYYMMDD` birthday format. ([advanced matching](https://developers.facebook.com/docs/meta-pixel/advanced/advanced-matching))
- **README `fbq('set', 'autoConfig', …)`** → boolean and pixel id were swapped. Correct order is `fbq('set', 'autoConfig', true, 'pixel_01')`. The code was already correct; only the example was wrong. ([advanced](https://developers.facebook.com/docs/meta-pixel/advanced))

### Docs
- Add root `CLAUDE.md` capturing the non-inferable context: monorepo layout, branching/release conventions, and the Meta Pixel semantics that are easy to get wrong (consent is global + revoke-before-init, autoConfig arg order, advanced-matching strings, `eventID` dedup, in-house glob vs minimatch).

## Verification
- `yarn build` (tsc) passes for `meta-pixel`.
- No usages of the changed fields elsewhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)