### PR TITLE
feat!: tighten pixel config API (autoConfig casing, string id)

### DIFF
--- a/packages/nuxt-meta-pixel/README.md
+++ b/packages/nuxt-meta-pixel/README.md
@@ -81,8 +81,8 @@ export default defineNuxtConfig({
 You can also flip it at runtime with the `NUXT_PUBLIC_METAPIXEL_ENABLED` environment variable.
 
 #### Pixel options
-- **id** `string` - your pixel id
-- **autoconfig** `boolean` (default: `true`) - enable or disable pixel autoconfig. [see more](https://developers.facebook.com/docs/meta-pixel/advanced/?locale=fr_FR)
+- **id** `string` - your pixel id (use a string — a numeric literal can lose precision on 15-16 digit ids)
+- **autoConfig** `boolean` (default: `true`) - enable or disable pixel auto configuration. [see more](https://developers.facebook.com/docs/meta-pixel/advanced/?locale=fr_FR)
 - **pageView** `string` (default: `**`) - glob expression to decide which route or not should send a PageView event automatically. [see more](https://www.npmjs.com/package/minimatch)
 
 ### GDPR consent

--- a/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
+++ b/packages/nuxt-meta-pixel/src/runtime/plugin.client.ts
@@ -24,7 +24,7 @@ export default defineNuxtPlugin(() => {
 
   for (const name in pixels) {
     const pixel = pixels[name]
-    init(pixel.id.toString(), pixel.autoconfig)
+    init(pixel.id, pixel.autoConfig)
   }
 
   const router = useRouter()
@@ -35,7 +35,7 @@ export default defineNuxtPlugin(() => {
       const pixel = pixels[name]
       const match = matchPath(to.path, pixel.pageView ?? '**')
       if (match) {
-        pageView(pixel.id.toString())
+        pageView(pixel.id)
       }
     }
   })

--- a/packages/nuxt-meta-pixel/src/typings.ts
+++ b/packages/nuxt-meta-pixel/src/typings.ts
@@ -1,6 +1,15 @@
 export interface Pixel {
-  id: number | string
-  autoconfig?: boolean
+  /**
+   * Your pixel id. A string — pixel ids are 15-16 digits and a numeric literal
+   * can silently lose precision past `Number.MAX_SAFE_INTEGER`.
+   */
+  id: string
+  /**
+   * Enable Meta's automatic configuration. Default `true`. Matches the Meta
+   * command `fbq('set', 'autoConfig', <boolean>, <pixelId>)`.
+   * @see https://developers.facebook.com/docs/meta-pixel/advanced
+   */
+  autoConfig?: boolean
   pageView?: string
 }
 


### PR DESCRIPTION
## Summary

Two **breaking** changes to the `metapixel.pixels` config shape in `nuxt-meta-pixel`, resolving review points #3 and #5.

### #3 — naming consistency (`autoConfig`)
- Rename pixel option `autoconfig` → **`autoConfig`**.
- Aligns with Meta's own command `fbq('set', 'autoConfig', <boolean>, <pixelId>)` ([advanced](https://developers.facebook.com/docs/meta-pixel/advanced)) and JS camelCase convention. The runtime `useMetaPixel().init({ autoConfig })` (on the dynamic-init branch) already uses this casing, so this removes the split.

### #5 — `id` precision
- Narrow `Pixel.id` from `number | string` to **`string`**.
- Pixel ids are 15-16 digits; a numeric literal can silently lose precision past `Number.MAX_SAFE_INTEGER`. The plugin no longer needs `.toString()`.

## ⚠️ Breaking change
In `nuxt.config.ts`:
```diff
 metapixel: {
   pixels: {
-    default: { id: 1176370652884847, autoconfig: false },
+    default: { id: '1176370652884847', autoConfig: false },
   }
 }
```
Warrants a major bump for `nuxt-meta-pixel`.

## Verification
- `npm run dev:prepare`, `npm run lint`, `npm run test` all pass (10/10).
- No remaining `autoconfig` references in the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)