### PR TITLE
docs: overhaul root and package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Meta Pixel
+
+A TypeScript monorepo for integrating the Meta (Facebook) Pixel into JavaScript and Nuxt applications.
+
+## Packages
+
+| Package | Description |
+| --- | --- |
+| [`meta-pixel`](packages/meta-pixel) | Framework-agnostic, **client-side only** TypeScript wrapper around Meta's `fbevents.js`. Typed standard events, multi-pixel, GDPR consent. |
+| [`nuxt-meta-pixel`](packages/nuxt-meta-pixel) | Nuxt 3 module built on `meta-pixel`: declare pixels in config, automatic route `PageView`, SSR-safe. |
+
+## Development
+
+This is a [Yarn](https://yarnpkg.com) workspaces monorepo (Node & Yarn versions are pinned via [Volta](https://volta.sh)).
+
+```bash
+yarn install
+
+# meta-pixel — build the TypeScript wrapper
+yarn workspace meta-pixel build
+
+# nuxt-meta-pixel — run the playground / tests / lint
+yarn workspace nuxt-meta-pixel dev:prepare   # generate type stubs first
+yarn workspace nuxt-meta-pixel dev
+yarn workspace nuxt-meta-pixel test
+yarn workspace nuxt-meta-pixel lint
+```
+
+Each package has its own README with usage details. Contributions are welcome.
+
+## License
+
+[MIT](https://opensource.org/licenses/MIT)

--- a/READme.md
+++ b/READme.md
@@ -1,3 +1,0 @@
-# Meta Pixel Packages
-- [`meta-pixel`](https://github.com/tanukijs/meta-pixel/tree/dev/packages/meta-pixel) embed the facebook's script to load your pixel in your javascript applications.
-- [`nuxt-meta-pixel`](https://github.com/tanukijs/meta-pixel/tree/dev/packages/nuxt-meta-pixel) the #1 library to manage your meta pixels in a Nuxt application.

--- a/packages/meta-pixel/README.md
+++ b/packages/meta-pixel/README.md
@@ -8,6 +8,12 @@
 
 <img src="https://raw.githubusercontent.com/tanukijs/meta-pixel/dev/events.png" style="max-width: 400px" />
 
+## Installation
+
+```bash
+npm i meta-pixel
+```
+
 ## Usage
 ### Manually setup pixels
 ```ts
@@ -48,6 +54,28 @@ fbq('track', 'CompleteRegistration')
 ```diff
 - const fbq = metapixel.addScriptDefault()
 + const fbq = metapixel.addScript(window, document, 'script', 'https://connect.facebook.net/en_US/fbevents.js')
+```
+
+## API
+
+`setup($fbq?)` returns a chainable controller. Pass your own `FacebookQuery` (e.g. from `addScriptDefault()`) or let it create one.
+
+| Member | Description |
+| --- | --- |
+| `$fbq` | The underlying Facebook query function — use it for raw, fully typed calls like `$fbq('track', 'Purchase', { value: 9.99, currency: 'EUR' })`. |
+| `init(pixelId, autoConfig = true)` | Initialize a pixel. `autoConfig` maps to `fbq('set', 'autoConfig', …)`. |
+| `pageView(pixelId?)` | Send a `PageView`. With an id it uses `trackSingle`; without one it tracks every pixel. |
+| `consent('grant' \| 'revoke')` | Global GDPR consent — the command takes **no** pixel id, so it applies to all pixels. Call `'revoke'` **before** `init` to hold delivery until you grant it. |
+
+`init`, `pageView` and `consent` are chainable (they return the controller). Standard events and their parameters are typed — e.g. `Purchase` requires `currency` and `value`, and advanced-matching fields are strings.
+
+```ts
+import { setup } from 'meta-pixel'
+
+setup()
+  .consent('revoke')   // hold delivery until the user opts in
+  .init('pixel_01')
+  .pageView()
 ```
 
 ## Resources

--- a/packages/nuxt-meta-pixel/README.md
+++ b/packages/nuxt-meta-pixel/README.md
@@ -7,7 +7,7 @@
 
 <img src="https://raw.githubusercontent.com/tanukijs/meta-pixel/dev/events.png" style="max-width: 400px" />
 
-I needed a Facebook pixel integration for a large project, but what I found didn't meet my expectations. That's why I took the time to understand how a pixel works and developed **a unique integration that's as simple as it should be**, and **much more effective than any other integration**.
+A Meta (Facebook) Pixel integration for Nuxt 3. Declare your pixels in config and the module loads them, sends `PageView` automatically on route changes, and exposes a fully typed `$fbq` everywhere — with first-class support for multiple pixels and GDPR consent.
 
 ## Features
 
@@ -16,7 +16,8 @@ I needed a Facebook pixel integration for a large project, but what I found didn
 - 📨 &nbsp;`PageView` event are sent automatically based on configurable route match.
 - ⚙️ &nbsp;Configurable via a `.env` file.
 - 🚀 &nbsp;All the possibilities offered by Facebook are available: `track`, `trackSingle`, `trackCustom` & `trackSingleCustom`.
-- ❤️ &nbsp;Contributions are  welcome.
+- 🔒 &nbsp;SSR-safe — the pixel only loads in the browser (client-only plugin); call `$fbq` from `onMounted` or client-side handlers.
+- ❤️ &nbsp;Contributions are welcome.
 
 ## Quick Setup
 
@@ -83,7 +84,7 @@ You can also flip it at runtime with the `NUXT_PUBLIC_METAPIXEL_ENABLED` environ
 #### Pixel options
 - **id** `string` - your pixel id (use a string — a numeric literal can lose precision on 15-16 digit ids)
 - **autoConfig** `boolean` (default: `true`) - enable or disable pixel auto configuration. [see more](https://developers.facebook.com/docs/meta-pixel/advanced/?locale=fr_FR)
-- **pageView** `string` (default: `**`) - glob expression to decide which route or not should send a PageView event automatically. [see more](https://www.npmjs.com/package/minimatch)
+- **pageView** `string` (default: `**`) - glob deciding which routes auto-send a `PageView`. Supported syntax: `**` (anything, including `/`), `*` (a single path segment), `?` (one character), and a leading `!` to negate the pattern.
 
 ### GDPR consent
 Meta's `consent` is a **global** setting — the command takes no pixel id, so it applies to **every** pixel at once. It's therefore a single top-level option, not per-pixel:


### PR DESCRIPTION
## Summary

Documentation pass across the three READMEs (review points #A/#B/#C).

### Root (`README.md`)
- **Rename `READme.md` → `README.md`** (canonical casing; `git mv` preserves history).
- Replace the 4-line stub with a real monorepo overview: package roles, **client-only / SSR-safe** notes, and Yarn-workspace dev commands.

### `meta-pixel`
- Add an **Installation** section (`npm i meta-pixel`).
- Add an **API reference** for `setup()` — `$fbq`, `init`, `pageView`, `consent` — documenting that `consent` is global and must be revoked **before** `init`.

### `nuxt-meta-pixel`
- Replace the subjective *"#1 / much more effective than any other"* tagline with a factual summary.
- Document the **actual supported `pageView` glob syntax** (`**`, `*`, `?`, leading `!`) instead of linking to minimatch — the in-house matcher only supports a subset.
- Add an **SSR-safe** note (client-only plugin; call `$fbq` from `onMounted`).

## Notes
- Doc-only; no code changes. README content reflects the current `dev` API (no `useMetaPixel` section — that lands with the dynamic-init feature).
- Images at root left untouched (discussed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)