### PR TITLE
feat(meta-pixel): forward advanced matching through setup().init()

### DIFF
--- a/packages/meta-pixel/README.md
+++ b/packages/meta-pixel/README.md
@@ -63,7 +63,7 @@ fbq('track', 'CompleteRegistration')
 | Member | Description |
 | --- | --- |
 | `$fbq` | The underlying Facebook query function — use it for raw, fully typed calls like `$fbq('track', 'Purchase', { value: 9.99, currency: 'EUR' })`. |
-| `init(pixelId, autoConfig = true)` | Initialize a pixel. `autoConfig` maps to `fbq('set', 'autoConfig', …)`. |
+| `init(pixelId, autoConfig = true, advancedMatching?)` | Initialize a pixel. `autoConfig` maps to `fbq('set', 'autoConfig', …)`. `advancedMatching` (typed `InitData`) forwards customer data — email, phone, etc., **all strings** — for better attribution. |
 | `pageView(pixelId?)` | Send a `PageView`. With an id it uses `trackSingle`; without one it tracks every pixel. |
 | `consent('grant' \| 'revoke')` | Global GDPR consent — the command takes **no** pixel id, so it applies to all pixels. Call `'revoke'` **before** `init` to hold delivery until you grant it. |
 
@@ -75,6 +75,16 @@ import { setup } from 'meta-pixel'
 setup()
   .consent('revoke')   // hold delivery until the user opts in
   .init('pixel_01')
+  .pageView()
+```
+
+Pass advanced matching to improve attribution (every field is a string):
+
+```ts
+import { setup } from 'meta-pixel'
+
+setup()
+  .init('pixel_01', true, { em: 'jane@doe.com', ph: '16505554444', db: '19910526' })
   .pageView()
 ```
 

--- a/packages/meta-pixel/src/meta-pixel.ts
+++ b/packages/meta-pixel/src/meta-pixel.ts
@@ -1,4 +1,4 @@
-import type { Consent, FacebookQuery, Setup } from './typings'
+import type { Consent, FacebookQuery, InitData, Setup } from './typings'
 
 export * from './typings'
 
@@ -46,9 +46,12 @@ export function setup($fbq: FacebookQuery = addScriptDefault()): Setup {
     return setup($fbq)
   }
 
-  function init (pixelId: string, autoconfig: boolean = true) {
-    $fbq('set', 'autoConfig', autoconfig, pixelId)
-    $fbq('init', pixelId)
+  // `advancedMatching` lets you pass hashed/plain customer data (email, phone, …)
+  // to Meta at init for better attribution. Every field is sent as a string.
+  // @see https://developers.facebook.com/docs/meta-pixel/advanced/advanced-matching/
+  function init (pixelId: string, autoConfig: boolean = true, advancedMatching?: InitData) {
+    $fbq('set', 'autoConfig', autoConfig, pixelId)
+    $fbq('init', pixelId, advancedMatching)
     return setup($fbq)
   }
   

--- a/packages/meta-pixel/src/typings.ts
+++ b/packages/meta-pixel/src/typings.ts
@@ -17,7 +17,7 @@ interface EventOptions {
 // Advanced matching. Every field is sent as a string — even digit-only ones
 // like `ph` (e.g. '16505554444') and `db` (YYYYMMDD, e.g. '19910526').
 // @see https://developers.facebook.com/docs/meta-pixel/advanced/advanced-matching
-type InitData = {
+export type InitData = {
   em?: string
   fn?: string
   ln?: string
@@ -87,7 +87,7 @@ export interface FacebookQuery {
 export interface Setup {
   $fbq: FacebookQuery
   consent(consent: Consent): Setup
-  init(pixelId: string, autoconfig?: boolean): Setup
+  init(pixelId: string, autoConfig?: boolean, advancedMatching?: InitData): Setup
   pageView(pixelId?: string): Setup
 }
 


### PR DESCRIPTION
## What

`setup().init()` previously accepted only `(pixelId, autoConfig)`, so there was no way to pass [advanced matching](https://developers.facebook.com/docs/meta-pixel/advanced/advanced-matching/) through the chainable API — even though the `InitData` type already existed and the raw `fbq('init', id, data)` call supports it.

## Changes

- `init(pixelId, autoConfig = true, advancedMatching?)` — new optional 3rd arg, forwarded to `fbq('init', pixelId, advancedMatching)`.
- Export `InitData` so consumers can type the advanced-matching object.
- Update `Setup` interface + README.

## Compatibility

Fully backward compatible — the new param is optional and existing positional calls (including `nuxt-meta-pixel`'s `init(pixel.id, pixel.autoConfig)`) are unaffected. `tsc --build` passes.

## Why now

The upcoming React binding (`meta-pixel-react`) will depend on this to expose advanced matching idiomatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)