### PR TITLE
chore: harden npm publish config (prepack, publishConfig)

### DIFF
--- a/packages/meta-pixel/package.json
+++ b/packages/meta-pixel/package.json
@@ -14,7 +14,8 @@
   "homepage": "https://github.com/tanukijs/meta-pixel#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tanukijs/meta-pixel.git"
+    "url": "git+https://github.com/tanukijs/meta-pixel.git",
+    "directory": "packages/meta-pixel"
   },
   "bugs": {
     "url": "https://github.com/tanukijs/meta-pixel/issues"
@@ -27,8 +28,13 @@
   "files": [
     "lib"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false,
   "scripts": {
-    "build": "tsc --build"
+    "build": "tsc --build",
+    "prepack": "tsc --build"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/nuxt-meta-pixel/package.json
+++ b/packages/nuxt-meta-pixel/package.json
@@ -15,10 +15,14 @@
   "homepage": "https://github.com/tanukijs/meta-pixel#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tanukijs/meta-pixel.git"
+    "url": "git+https://github.com/tanukijs/meta-pixel.git",
+    "directory": "packages/nuxt-meta-pixel"
   },
   "bugs": {
     "url": "https://github.com/tanukijs/meta-pixel/issues"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Why

`meta-pixel`'s `lib/` (and `nuxt-meta-pixel`'s/`meta-pixel-react`'s `dist/`) are gitignored, so a fresh checkout has no build output. `nuxt-meta-pixel` already has a `prepack` script (npm runs it before `pack`/`publish`), but **`meta-pixel` had none** — a direct `npm publish` could ship a stale or empty tarball.

## Changes

**`meta-pixel`**
- `prepack: tsc --build` — guarantees a build before packing.
- `sideEffects: false` — pure wrapper, lets bundlers tree-shake.
- `publishConfig.access: public` + `repository.directory`.

**`nuxt-meta-pixel`**
- `publishConfig.access: public` + `repository.directory`.

## Not done (on purpose)

- **No `.npmignore`** — both packages use a `files` allowlist, which takes precedence and is safer than a denylist. `npm pack --dry-run` confirms only `lib`/`dist` + README/CHANGELOG + `package.json` are published.
- **No committed `.npmrc`** — npm auth belongs in `NODE_AUTH_TOKEN` / CI secrets, not the repo.

> `meta-pixel-react` already got the same treatment in #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)