### PR TITLE
chore: release meta-pixel@2.0.0, nuxt-meta-pixel@3.0.0, meta-pixel-react@0.1.0

### DIFF
--- a/packages/meta-pixel-react/CHANGELOG.md
+++ b/packages/meta-pixel-react/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## v0.1.0
+
+Initial release — React bindings for `meta-pixel`.
+
+### Added
+- `<MetaPixelProvider>` — loads `fbevents.js` and initializes the configured
+  pixels in a client effect (SSR/RSC-safe; never touches `window`/`document`
+  during render). Honors a global `enabled` toggle and the GDPR
+  revoke-before-init flow.
+- `useMetaPixel()` — typed hook returning `{ $fbq, consent, pageView }`; `$fbq`
+  carries the full event typing from `meta-pixel`.
+- Automatic route `PageView` via an optional `pathname` prop, glob-matched per
+  pixel (router-agnostic — works with next/navigation, react-router, …).
+- Forwards advanced matching per pixel through `meta-pixel`'s `init()`.

--- a/packages/meta-pixel-react/package.json
+++ b/packages/meta-pixel-react/package.json
@@ -53,7 +53,7 @@
     "release": "npm run test && npm run build && changelogen --release && npm publish && git push --follow-tags"
   },
   "dependencies": {
-    "meta-pixel": "workspace:^"
+    "meta-pixel": "^2.0.0"
   },
   "peerDependencies": {
     "react": ">=18"

--- a/packages/meta-pixel/CHANGELOG.md
+++ b/packages/meta-pixel/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v2.0.0
+
+### Breaking
+- Types tightened to match Meta's documented API. Existing code using the old
+  shapes will no longer type-check:
+  - `contents` is now `Array<{ id: string, quantity: number }>` (was a
+    one-element tuple keyed by `name`).
+  - Advanced-matching `ph` and `db` are now `string` (were `number`), so
+    digit-only phone numbers and `YYYYMMDD` birthdays keep their leading zeros.
+  ([#33](https://github.com/tanukijs/meta-pixel/pull/33))
+
+### Added
+- `setup().init()` accepts an optional advanced-matching object:
+  `init(pixelId, autoConfig?, advancedMatching?)`, forwarded to
+  `fbq('init', id, data)`. The `InitData` type is now exported.
+  ([#37](https://github.com/tanukijs/meta-pixel/pull/37))
+
+### Changed
+- The `init` parameter `autoconfig` was renamed to `autoConfig` (positional, so
+  callers are unaffected).
+- Packaging: add a `prepack` build step, `sideEffects: false`, `publishConfig`,
+  `repository.directory`, and a bundled `LICENSE`.
+
 ## v1.2.0
 
 ### Added

--- a/packages/meta-pixel/package.json
+++ b/packages/meta-pixel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-pixel",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "tanukijs <tanuki.contact@gmail.com>",
   "description": "Wrapper for meta pixels",

--- a/packages/nuxt-meta-pixel/CHANGELOG.md
+++ b/packages/nuxt-meta-pixel/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v3.0.0
+
+### Breaking
+- **Config restructured.** `ModuleOptions` is now `{ enabled?, consent?, pixels }`
+  where `pixels` is a `Record<string, Pixel>` map. The previous flat shape and
+  per-pixel `consent` field are gone — `consent` is now a single global option
+  (`'revoke'`), matching Meta's global consent command. Runtime env vars become
+  `NUXT_PUBLIC_METAPIXEL_PIXELS_<NAME>_ID`.
+  ([#30](https://github.com/tanukijs/meta-pixel/pull/30))
+- **Pixel config tightened**: `autoConfig` casing and string pixel ids enforced.
+  ([#34](https://github.com/tanukijs/meta-pixel/pull/34))
+
+### Added
+- Global `enabled` toggle (default `true`). When `false` the module loads and
+  sends nothing but still provides a no-op `$fbq`. Override at runtime with
+  `NUXT_PUBLIC_METAPIXEL_ENABLED`.
+  ([#31](https://github.com/tanukijs/meta-pixel/pull/31), [#15](https://github.com/tanukijs/meta-pixel/issues/15), [#16](https://github.com/tanukijs/meta-pixel/issues/16))
+- **Nuxt 4 support** while keeping Nuxt 3 compatibility.
+  ([#36](https://github.com/tanukijs/meta-pixel/pull/36))
+
+### Changed
+- Bump the `meta-pixel` dependency to `^2.0.0`.
+- Packaging: add `publishConfig`, `repository.directory`, and a bundled `LICENSE`.
+
 ## v2.1.0
 
 ### Added

--- a/packages/nuxt-meta-pixel/package.json
+++ b/packages/nuxt-meta-pixel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-meta-pixel",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "license": "MIT",
   "author": "tanukijs <tanuki.contact@gmail.com>",
   "description": "Nuxt best module to use Facebook's pixels in your application.",
@@ -55,7 +55,7 @@
   "dependencies": {
     "@nuxt/kit": "^3.13.0 || ^4.0.0",
     "defu": "^6.1.7",
-    "meta-pixel": "^1.2.0"
+    "meta-pixel": "^2.0.0"
   },
   "devDependencies": {
     "@nuxt/devtools": "^2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8082,7 +8082,7 @@ __metadata:
     "@types/react": "npm:^18.3.0"
     "@types/react-dom": "npm:^18.3.0"
     jsdom: "npm:^25.0.0"
-    meta-pixel: "workspace:^"
+    meta-pixel: "npm:^2.0.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tsup: "npm:^8.3.0"
@@ -8093,7 +8093,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"meta-pixel@npm:^1.2.0, meta-pixel@workspace:^, meta-pixel@workspace:packages/meta-pixel":
+"meta-pixel@npm:^2.0.0, meta-pixel@workspace:packages/meta-pixel":
   version: 0.0.0-use.local
   resolution: "meta-pixel@workspace:packages/meta-pixel"
   dependencies:
@@ -8718,7 +8718,7 @@ __metadata:
     changelogen: "npm:^0.6.2"
     defu: "npm:^6.1.7"
     eslint: "npm:^9.39.4"
-    meta-pixel: "npm:^1.2.0"
+    meta-pixel: "npm:^2.0.0"
     nuxt: "npm:^4.0.0"
     typescript: "npm:^5.9.3"
     vitest: "npm:^4.1.6"


### PR DESCRIPTION
Version bumps + CHANGELOGs ahead of publishing all three packages.

| Package | From | To | Why |
|---|---|---|---|
| `meta-pixel` | 1.2.0 | **2.0.0** | Breaking: types tightened to Meta spec (#33 — `contents` `{id,quantity}[]`, `ph`/`db` strings). Plus additive advanced-matching `init()` arg (#37). |
| `nuxt-meta-pixel` | 2.1.0 | **3.0.0** | Breaking: config restructure (#30) + tightened pixel config (#34). Adds `enabled` toggle (#31) and Nuxt 4 support (#36). Dep → `meta-pixel@^2.0.0`. |
| `meta-pixel-react` | — | **0.1.0** | First release. |

### Notable

- `meta-pixel-react`'s `meta-pixel` dependency is pinned to `^2.0.0` (was `workspace:^`) so a plain `npm publish` emits a valid range. Yarn still symlinks the local workspace in dev (verified).

### Publish order (after merge)

`meta-pixel` first (the others depend on it), then `nuxt-meta-pixel` and `meta-pixel-react`. `prepack` rebuilds each on publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)